### PR TITLE
feat: XDG paths, install script, and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ autopr.toml
 
 # Build output
 ap
+dist/
 
 # Runtime
 .repos/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+version: 2
+
+builds:
+  - main: ./cmd/autopr
+    binary: ap
+    ldflags:
+      - -s -w
+      - -X autopr/cmd/autopr/cli.version={{.Version}}
+      - -X autopr/cmd/autopr/cli.commit={{.ShortCommit}}
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "ap_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+
+release:
+  github:
+    owner: ashwath-ramesh
+    name: autopr

--- a/autopr.toml.example
+++ b/autopr.toml.example
@@ -1,28 +1,30 @@
 # AutoPR Configuration
-# Copy to autopr.toml and customize.
+# Run `ap init` for interactive setup, or copy this file and customize.
+#
+# Tokens: store in ~/.config/autopr/credentials.toml or set env vars
+# (GITHUB_TOKEN, GITLAB_TOKEN, SENTRY_TOKEN, AUTOPR_WEBHOOK_SECRET)
+#
+# Data files (DB, repos) default to ~/.local/share/autopr/
+# State files (logs, PID) default to ~/.local/state/autopr/
+# Override with XDG_DATA_HOME / XDG_STATE_HOME or set paths explicitly below.
+# Run `ap paths` to see resolved locations.
 
-db_path = "autopr.db"
-repos_root = ".repos"
-log_level = "info"         # debug, info, warn, error
-# log_file = "autopr.log" # Uncomment to log to file instead of stderr
+# db_path = "/custom/path/autopr.db"     # default: ~/.local/share/autopr/autopr.db
+# repos_root = "/custom/path/repos"      # default: ~/.local/share/autopr/repos
+# log_file = "/custom/path/autopr.log"   # default: ~/.local/state/autopr/autopr.log
+log_level = "info"                        # debug, info, warn, error
 
 [daemon]
-webhook_port = 8080
+webhook_port = 9847
 # webhook_secret = ""      # Set via AUTOPR_WEBHOOK_SECRET env var
 max_workers = 3
 max_iterations = 3
 sync_interval = "5m"
-pid_file = "autopr.pid"
+# pid_file = "/custom/path/autopr.pid"   # default: ~/.local/state/autopr/autopr.pid
 # auto_pr = false               # Set true to auto-create PRs after tests pass
 
-[tokens]
-# Prefer environment variables: GITLAB_TOKEN, GITHUB_TOKEN, SENTRY_TOKEN
-# gitlab = ""
-# github = ""
-# sentry = ""
-
-[sentry]
-base_url = "https://sentry.io"
+# [sentry]
+# base_url = "https://sentry.io"  # uncomment for self-hosted Sentry
 
 [llm]
 provider = "claude"  # claude or codex
@@ -46,8 +48,8 @@ base_branch = "main"
   # org = "myorg"
   # project = "my-project"
 
+  # Override default LLM prompts with custom markdown files:
   # [projects.prompts]
-  # plan = "prompts/plan.md"
-  # plan_review = "prompts/plan_review.md"
-  # implement = "prompts/implement.md"
-  # code_review = "prompts/code_review.md"
+  # plan = "/path/to/plan.md"
+  # implement = "/path/to/implement.md"
+  # code_review = "/path/to/code_review.md"

--- a/cmd/autopr/cli/init.go
+++ b/cmd/autopr/cli/init.go
@@ -162,11 +162,12 @@ const configTemplate = `# AutoPR configuration
 #
 # Tokens: store in ~/.config/autopr/credentials.toml or set env vars
 # (GITHUB_TOKEN, GITLAB_TOKEN, SENTRY_TOKEN, AUTOPR_WEBHOOK_SECRET)
+#
+# Data files (DB, repos) default to ~/.local/share/autopr/
+# State files (logs, PID) default to ~/.local/state/autopr/
+# Override with XDG_DATA_HOME / XDG_STATE_HOME or set paths explicitly below.
 
-db_path = "autopr.db"
-repos_root = ".repos"
 log_level = "info"              # debug|info|warn|error
-log_file = "autopr.log"         # relative to config dir
 
 [daemon]
 webhook_port = 9847
@@ -174,7 +175,6 @@ webhook_secret = ""             # override via AUTOPR_WEBHOOK_SECRET env var
 max_workers = 3
 max_iterations = 3              # implement<->review loop default
 sync_interval = "5m"            # GitHub/Sentry poll interval
-pid_file = "autopr.pid"
 auto_pr = false                 # set true to auto-create PRs after tests pass
 
 # [sentry]
@@ -198,11 +198,11 @@ base_branch = "main"
   # org = "my-org"
   # project = "my-project"
 
+  # Override default LLM prompts with custom markdown files:
   # [projects.prompts]
-  # plan = "templates/prompts/plan.md"
-  # plan_review = "templates/prompts/plan_review.md"
-  # implement = "templates/prompts/implement.md"
-  # code_review = "templates/prompts/code_review.md"
+  # plan = "/path/to/plan.md"
+  # implement = "/path/to/implement.md"
+  # code_review = "/path/to/code_review.md"
 
 # --- GitLab example ---
 # [[projects]]

--- a/cmd/autopr/cli/paths.go
+++ b/cmd/autopr/cli/paths.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+
+	"autopr/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+var pathsCmd = &cobra.Command{
+	Use:   "paths",
+	Short: "Show where AutoPR stores its files",
+	RunE:  runPaths,
+}
+
+func init() {
+	rootCmd.AddCommand(pathsCmd)
+}
+
+func runPaths(cmd *cobra.Command, args []string) error {
+	configDir, _ := config.ConfigDir()
+	dataDir, _ := config.DataDir()
+	stateDir, _ := config.StateDir()
+
+	fmt.Printf("Config:  %s\n", configDir)
+	fmt.Printf("Data:    %s\n", dataDir)
+	fmt.Printf("State:   %s\n", stateDir)
+	fmt.Println()
+
+	// If a config is loadable, show resolved paths.
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil // don't error — base dirs are still useful
+	}
+
+	fmt.Printf("DB:      %s\n", cfg.DBPath)
+	fmt.Printf("Repos:   %s\n", cfg.ReposRoot)
+	fmt.Printf("Log:     %s\n", cfg.LogFile)
+	fmt.Printf("PID:     %s\n", cfg.Daemon.PIDFile)
+	return nil
+}

--- a/cmd/autopr/cli/start.go
+++ b/cmd/autopr/cli/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"autopr/internal/daemon"
 
@@ -33,6 +34,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 	level := cfg.SlogLevel()
 	opts := &slog.HandlerOptions{Level: level}
 	if cfg.LogFile != "" {
+		if err := os.MkdirAll(filepath.Dir(cfg.LogFile), 0o755); err != nil {
+			return fmt.Errorf("create log dir: %w", err)
+		}
 		f, err := os.OpenFile(cfg.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return fmt.Errorf("open log file: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,13 +177,25 @@ func LoadMinimal(path string) (*Config, error) {
 
 func applyDefaults(cfg *Config) {
 	if cfg.DBPath == "" {
-		cfg.DBPath = "autopr.db"
+		if d, err := DataDir(); err == nil {
+			cfg.DBPath = filepath.Join(d, "autopr.db")
+		} else {
+			cfg.DBPath = "autopr.db"
+		}
 	}
 	if cfg.ReposRoot == "" {
-		cfg.ReposRoot = ".repos"
+		if d, err := DataDir(); err == nil {
+			cfg.ReposRoot = filepath.Join(d, "repos")
+		} else {
+			cfg.ReposRoot = ".repos"
+		}
 	}
 	if cfg.LogFile == "" {
-		cfg.LogFile = "autopr.log"
+		if d, err := StateDir(); err == nil {
+			cfg.LogFile = filepath.Join(d, "autopr.log")
+		} else {
+			cfg.LogFile = "autopr.log"
+		}
 	}
 	if cfg.LogLevel == "" {
 		cfg.LogLevel = "info"
@@ -201,7 +213,11 @@ func applyDefaults(cfg *Config) {
 		cfg.Daemon.SyncInterval = "5m"
 	}
 	if cfg.Daemon.PIDFile == "" {
-		cfg.Daemon.PIDFile = "autopr.pid"
+		if d, err := StateDir(); err == nil {
+			cfg.Daemon.PIDFile = filepath.Join(d, "autopr.pid")
+		} else {
+			cfg.Daemon.PIDFile = "autopr.pid"
+		}
 	}
 	if cfg.Sentry.BaseURL == "" {
 		cfg.Sentry.BaseURL = "https://sentry.io"

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -36,3 +36,31 @@ func CredentialsPath() (string, error) {
 	}
 	return filepath.Join(dir, "credentials.toml"), nil
 }
+
+// DataDir returns the autopr data directory, respecting XDG_DATA_HOME.
+// Defaults to ~/.local/share/autopr/.
+func DataDir() (string, error) {
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "autopr"), nil
+}
+
+// StateDir returns the autopr state directory, respecting XDG_STATE_HOME.
+// Defaults to ~/.local/state/autopr/.
+func StateDir() (string, error) {
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(base, "autopr"), nil
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -25,6 +25,9 @@ import (
 // Blocks until SIGINT/SIGTERM is received.
 func Run(cfg *config.Config, foreground bool) error {
 	// Write PID file.
+	if err := os.MkdirAll(filepath.Dir(cfg.Daemon.PIDFile), 0o755); err != nil {
+		return fmt.Errorf("create pid dir: %w", err)
+	}
 	if err := WritePID(cfg.Daemon.PIDFile); err != nil {
 		return err
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="ashwath-ramesh/autopr"
+BINARY="ap"
+
+# --- Detect OS/Arch ---
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+  darwin) ;;
+  *) echo "Error: only macOS is supported right now." >&2; exit 1 ;;
+esac
+
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  arm64)   ARCH="arm64" ;;
+  aarch64) ARCH="arm64" ;;
+  *) echo "Error: unsupported architecture $ARCH" >&2; exit 1 ;;
+esac
+
+# --- Get latest version ---
+echo "Fetching latest release..."
+TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+
+if [ -z "$TAG" ]; then
+  echo "Error: could not determine latest release." >&2
+  exit 1
+fi
+
+echo "Installing ap v${TAG} (${OS}/${ARCH})..."
+
+# --- Download and extract ---
+TARBALL="ap_${TAG}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/v${TAG}/${TARBALL}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "$URL" -o "${TMP}/${TARBALL}"
+tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
+
+# --- Install binary ---
+if [ -w /usr/local/bin ]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+mv "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+chmod +x "${INSTALL_DIR}/${BINARY}"
+
+# macOS: remove quarantine attribute
+xattr -d com.apple.quarantine "${INSTALL_DIR}/${BINARY}" 2>/dev/null || true
+
+echo ""
+echo "Installed: ${INSTALL_DIR}/${BINARY} (v${TAG})"
+
+# --- Check PATH ---
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  echo ""
+  echo "Add to your PATH:"
+  echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+fi
+
+echo ""
+echo "Get started:"
+echo "  ap init"


### PR DESCRIPTION
## Summary
- Default file paths now follow the XDG Base Directory Specification (data → `~/.local/share/autopr/`, state → `~/.local/state/autopr/`, config stays in `~/.config/autopr/`)
- Explicit paths in config still resolve correctly (backward compatible)
- New `ap paths` command shows where all files are stored
- GoReleaser config + GitHub Actions release workflow for macOS (amd64 + arm64)
- Curl install script: `curl -fsSL .../install.sh | bash`
- Updated README with Install/Quick Start front and center, XDG file locations, and `ap paths`
- Updated `autopr.toml.example` and `ap init` config template

## Test plan
- [x] `go test ./internal/config/...` — 7 tests pass (3 new XDG tests)
- [x] `go build ./...` — clean
- [x] `goreleaser release --snapshot --clean` — builds macOS tarballs
- [x] Built binary: `ap --version` reports version + commit, `ap paths` shows correct XDG dirs
- [x] `ap start -f` creates DB in `~/.local/share/autopr/`, logs in `~/.local/state/autopr/`
- [x] `XDG_DATA_HOME`/`XDG_STATE_HOME` env overrides work
- [ ] Tag `v0.1.0` + push to test GitHub Actions release workflow