### PR TITLE
fix: false token warning and add daemon step to init

### DIFF
--- a/cmd/autopr/cli/init.go
+++ b/cmd/autopr/cli/init.go
@@ -127,7 +127,8 @@ func runGlobalInit() error {
 	fmt.Printf("Database initialized: %s\n", cfg.DBPath)
 	fmt.Println("\nNext steps:")
 	fmt.Printf("  1. Edit your config to add projects: ap config\n")
-	fmt.Printf("  2. Start the TUI:                    ap tui\n")
+	fmt.Printf("  2. Start the daemon:                 ap start\n")
+	fmt.Printf("  3. Start the TUI:                    ap tui\n")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- **Fix false token warning**: `warnTokensInFile` was triggering when the GitHub token came from `credentials.toml` (the intended location) because `applyCredentialsAndEnv` merged it into `cfg.Tokens` before the check ran. Now we snapshot the config-file-only tokens before merging and only warn on those.
- **Add `ap start` to init output**: New users weren't told how to start the daemon. Added it as step 2 in the "Next steps" output of `ap init`.

## Test plan
- [ ] Run `ap init` and verify no spurious token warning appears
- [ ] Verify "Next steps" now lists `ap start` as step 2
- [ ] Put a token in `config.toml` `[tokens]` section and verify the warning still fires