### PR TITLE
feat: daemonize ap start by default

### DIFF
--- a/cmd/autopr/cli/start.go
+++ b/cmd/autopr/cli/start.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
+	"time"
 
+	"autopr/internal/config"
 	"autopr/internal/daemon"
 
 	"github.com/spf13/cobra"
@@ -30,7 +34,19 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Configure logging.
+	// Check if already running.
+	if daemon.IsRunning(cfg.Daemon.PIDFile) {
+		return fmt.Errorf("daemon is already running (see %s)", cfg.Daemon.PIDFile)
+	}
+
+	if foreground {
+		return runForeground(cfg)
+	}
+	return runBackground(cfg)
+}
+
+// runForeground configures logging and runs the daemon in the current process.
+func runForeground(cfg *config.Config) error {
 	level := cfg.SlogLevel()
 	opts := &slog.HandlerOptions{Level: level}
 	if cfg.LogFile != "" {
@@ -47,11 +63,60 @@ func runStart(cmd *cobra.Command, args []string) error {
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, opts)))
 	}
 
-	// Check if already running.
-	if daemon.IsRunning(cfg.Daemon.PIDFile) {
-		return fmt.Errorf("daemon is already running (see %s)", cfg.Daemon.PIDFile)
+	fmt.Println("Starting autopr daemon in foreground...")
+	return daemon.Run(cfg, foreground)
+}
+
+// runBackground re-execs the current binary with --foreground as a detached
+// child process, then waits briefly to verify it started successfully.
+func runBackground(cfg *config.Config) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
 	}
 
-	fmt.Println("Starting autopr daemon...")
-	return daemon.Run(cfg, foreground)
+	// Build child args: start --foreground, plus --config if the user passed one.
+	childArgs := []string{"start", "--foreground"}
+	if cfgPath != "" {
+		childArgs = append(childArgs, "--config", cfgPath)
+	}
+
+	// Ensure log directory exists and open the log file for the child.
+	logPath := cfg.LogFile
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+	defer logFile.Close()
+
+	child := exec.Command(exe, childArgs...)
+	child.Stdout = logFile
+	child.Stderr = logFile
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := child.Start(); err != nil {
+		return fmt.Errorf("start daemon: %w", err)
+	}
+
+	// Race child.Wait() against a grace period timer. We must reap the child
+	// to detect early exits — a zombie still passes kill(pid, 0).
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- child.Wait() }()
+
+	select {
+	case err := <-waitCh:
+		// Child exited during the grace period — it crashed.
+		if err != nil {
+			return fmt.Errorf("daemon exited immediately (%v); check logs at %s", err, logPath)
+		}
+		return fmt.Errorf("daemon exited immediately; check logs at %s", logPath)
+	case <-time.After(500 * time.Millisecond):
+		// Still running after 500ms — detach and let it go.
+	}
+
+	fmt.Printf("Daemon started (pid %d), log: %s\n", child.Process.Pid, logPath)
+	return nil
 }

--- a/internal/daemon/pid.go
+++ b/internal/daemon/pid.go
@@ -53,7 +53,7 @@ func IsRunning(path string) bool {
 	if err != nil {
 		return false
 	}
-	return processAlive(pid)
+	return ProcessAlive(pid)
 }
 
 // RemovePID removes the PID file.
@@ -61,7 +61,8 @@ func RemovePID(path string) {
 	_ = os.Remove(path)
 }
 
-func processAlive(pid int) bool {
+// ProcessAlive checks whether the given PID is still running.
+func ProcessAlive(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false
@@ -75,7 +76,7 @@ func cleanStalePID(path string) bool {
 		_ = os.Remove(path)
 		return true
 	}
-	if !processAlive(pid) {
+	if !ProcessAlive(pid) {
 		_ = os.Remove(path)
 		return true
 	}


### PR DESCRIPTION
## Summary
- `ap start` now re-execs itself as a detached background process by default, prints the PID and log path, and returns to the shell immediately
- `ap start --foreground` preserves the existing blocking behavior
- Exported `ProcessAlive` from `internal/daemon/pid.go` for reuse
- Uses wait-based child health check instead of `kill(pid, 0)` to avoid zombie false positives

## Test plan
- [ ] `go build -o ap ./cmd/autopr && ./ap start` → prints PID + log path, returns immediately
- [ ] `./ap start` again → says "daemon is already running"
- [ ] `./ap stop` → stops the background process
- [ ] `./ap start --foreground` → blocks the terminal
- [ ] `go test ./...` → all tests pass