### PR TITLE
feat: add TUI auto-refresh and fix stale state bugs

### DIFF
--- a/cmd/autopr/cli/stop.go
+++ b/cmd/autopr/cli/stop.go
@@ -43,6 +43,6 @@ func runStop(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("signal process %d: %w", pid, err)
 	}
 
-	fmt.Printf("Sent SIGTERM to daemon (pid %d)\n", pid)
+	fmt.Printf("Stopping daemon (pid %d)...\n", pid)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add 3-second tick-based auto-refresh so the TUI stays current without manual `r` keypress
- Fix stale `m.selected` pointer after job list refresh so keybindings (cancel, approve, etc.) see the latest job state
- Cache `isDaemonRunning` on tick instead of calling per-render (eliminates ~10 unnecessary fs reads/syscalls per cycle)
- Extract `startConfirm()` helper to deduplicate 5 confirmation call sites
- Simplify `cleanupCancelledJobWorktree` — remove speculative path guess and stat-after-removal check
- Clamp `sessCursor` on session refresh instead of resetting to 0 (prevents cursor jumping every 3s)
- Clear confirmation state when a job disappears during refresh (prevents ghost prompts)
- Fix `ap stop` message to reflect async nature of SIGTERM

## Test plan

- [x] `go test ./internal/tui/...` — all 7 tests pass
- [x] `go build ./...` — clean build
- [ ] Manual: open TUI, verify jobs refresh automatically every ~3s
- [ ] Manual: navigate to a running job, verify `c cancel` hint appears and works