### PR TITLE
Fix: defer branch push to approval time

### DIFF
--- a/cmd/autopr/cli/approve.go
+++ b/cmd/autopr/cli/approve.go
@@ -61,6 +61,11 @@ func runApprove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load issue: %w", err)
 	}
 
+	// Push branch to remote before creating PR.
+	if err := git.PushBranch(cmd.Context(), job.WorktreePath, job.BranchName); err != nil {
+		return fmt.Errorf("push branch: %w", err)
+	}
+
 	prURL := job.PRURL
 	if prURL != "" {
 		// PR already created (e.g. by auto_pr), skip creation.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -318,6 +318,11 @@ func (r *Runner) maybeAutoPR(ctx context.Context, jobID string, issue db.Issue, 
 		return nil
 	}
 
+	// Push branch to remote before creating PR.
+	if err := git.PushBranch(ctx, job.WorktreePath, job.BranchName); err != nil {
+		return fmt.Errorf("push branch for auto-PR: %w", err)
+	}
+
 	slog.Info("auto_pr enabled, creating PR", "job", jobID)
 
 	prTitle, prBody := BuildPRContent(ctx, r.store, job, issue)

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -231,14 +231,6 @@ func (r *Runner) runTests(ctx context.Context, jobID string, issue db.Issue, pro
 		return errTestsFailed
 	}
 
-	// Push branch.
-	if err := git.PushBranch(ctx, workDir, job.BranchName); err != nil {
-		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
-			return context.Canceled
-		}
-		slog.Warn("push failed", "err", err)
-	}
-
 	slog.Info("test step completed", "job", jobID)
 	return nil
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -305,6 +305,11 @@ func (m Model) executeApprove() tea.Msg {
 		return actionResultMsg{action: "approve", err: fmt.Errorf("load issue: %w", err)}
 	}
 
+	// Push branch to remote before creating PR.
+	if err := git.PushBranch(ctx, job.WorktreePath, job.BranchName); err != nil {
+		return actionResultMsg{action: "approve", err: fmt.Errorf("push branch: %w", err)}
+	}
+
 	prURL := job.PRURL
 	if prURL == "" {
 		proj, ok := m.cfg.ProjectByName(job.ProjectName)


### PR DESCRIPTION
## Summary
- Removes unconditional `git.PushBranch` from `runTests()` so rejected/unreviewed jobs no longer push stale branches to the remote
- Adds push to `maybeAutoPR()` for the `auto_pr = true` path
- Adds push to CLI `ap approve` and TUI approve flows for the manual approval path

Closes #33

## Test plan
- [x] `go build ./internal/pipeline/... ./cmd/autopr/cli/...` compiles cleanly
- [x] `go test ./internal/pipeline/... ./cmd/autopr/cli/...` — all 7 tests pass
- [x] `go vet` clean