### PR TITLE
fix: prevent duplicate active jobs per issue (#32)

### DIFF
--- a/internal/issuesync/syncer.go
+++ b/internal/issuesync/syncer.go
@@ -2,6 +2,7 @@ package issuesync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -88,6 +89,10 @@ func (s *Syncer) createJobIfNeeded(ctx context.Context, ffid, projectName string
 
 	jobID, err := s.store.CreateJob(ctx, ffid, projectName, s.cfg.Daemon.MaxIterations)
 	if err != nil {
+		if errors.Is(err, db.ErrDuplicateActiveJob) {
+			slog.Debug("sync: active job already exists, skipping", "ffid", ffid)
+			return
+		}
 		slog.Error("sync: create job", "err", err)
 		return
 	}


### PR DESCRIPTION
## Summary
- Add `ErrDuplicateActiveJob` sentinel error to gracefully handle the SQLite UNIQUE constraint on `idx_jobs_one_active_per_issue`, replacing confusing raw DB errors
- Handle the sentinel silently in sync (debug log) and webhook (202 Accepted) paths so duplicate job creation from race conditions is a no-op
- Guard `ResetJobForRetry` with a `NOT EXISTS` subquery preventing retry when another active sibling job exists, with a clear diagnostic error including the conflicting job ID
- Add proactive active-sibling check in `ap retry` CLI before calling reset for better UX
- Add `GetActiveJobForIssue` DB method (returns job ID, not just bool)

## Test plan
- [x] `TestCreateJobDuplicateActiveReturnsErrDuplicate` — second CreateJob returns sentinel
- [x] `TestResetJobForRetryBlockedByActiveSibling` — retry blocked with clear message including sibling ID
- [x] `TestRetrySucceedsWhenNoActiveSibling` — retry works when all siblings are terminal
- [x] `go test ./...` — full suite passes

Closes #32