### PR TITLE
feat: retry/backoff, idempotent GitLab MR, paginated issue sync

### DIFF
--- a/internal/git/pr_test.go
+++ b/internal/git/pr_test.go
@@ -1,0 +1,108 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateGitLabMR_409ReturnsExisting(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/merge_requests"):
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, `{"message":"Another open merge request already exists"}`)
+
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/merge_requests"):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]string{
+				{"web_url": "https://gitlab.com/org/repo/-/merge_requests/42"},
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := CreateGitLabMR(context.Background(), "tok", srv.URL, "123", "feat/branch", "main", "title", "desc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://gitlab.com/org/repo/-/merge_requests/42" {
+		t.Fatalf("want existing MR URL, got %q", got)
+	}
+}
+
+func TestCreateGitLabMR_409NoExistingReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/merge_requests"):
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, `{"message":"conflict"}`)
+
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/merge_requests"):
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `[]`)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := CreateGitLabMR(context.Background(), "tok", srv.URL, "123", "feat/branch", "main", "title", "desc")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 409") {
+		t.Fatalf("want HTTP 409 error, got: %v", err)
+	}
+}
+
+func TestFindGitLabMR_ReturnsFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]string{
+			{"web_url": "https://gitlab.com/org/repo/-/merge_requests/10"},
+			{"web_url": "https://gitlab.com/org/repo/-/merge_requests/11"},
+		})
+	}))
+	defer srv.Close()
+
+	got, err := findGitLabMR(context.Background(), "tok", srv.URL, "123", "feat/branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://gitlab.com/org/repo/-/merge_requests/10" {
+		t.Fatalf("want first MR URL, got %q", got)
+	}
+}
+
+func TestFindGitLabMR_EmptyWhenNoMatches(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	got, err := findGitLabMR(context.Background(), "tok", srv.URL, "123", "feat/branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("want empty string, got %q", got)
+	}
+}

--- a/internal/httputil/retry.go
+++ b/internal/httputil/retry.go
@@ -1,0 +1,173 @@
+package httputil
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RetryConfig controls the retry behavior.
+type RetryConfig struct {
+	MaxAttempts  int
+	BaseDelay    time.Duration
+	MaxDelay     time.Duration
+	JitterFactor float64 // fraction of delay to randomize (0..1)
+}
+
+// DefaultRetryConfig returns sensible defaults for API calls.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:  4,
+		BaseDelay:    1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		JitterFactor: 0.25,
+	}
+}
+
+// Do executes an HTTP request with retry/backoff. buildReq is called per
+// attempt because request bodies are consumed on read and must be recreated.
+//
+// Retries on: network errors, HTTP 429, HTTP 5xx.
+// Fails fast on 4xx (non-429) — the response is returned with body intact.
+func Do(ctx context.Context, buildReq func() (*http.Request, error), cfg RetryConfig) (*http.Response, error) {
+	var lastErr error
+
+	for attempt := range cfg.MaxAttempts {
+		req, err := buildReq()
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < cfg.MaxAttempts-1 {
+				slog.Warn("httputil: retrying after network error",
+					"attempt", attempt+1,
+					"max", cfg.MaxAttempts,
+					"err", err,
+				)
+				if sleepErr := sleepWithContext(ctx, backoff(cfg, attempt, nil)); sleepErr != nil {
+					return nil, sleepErr
+				}
+			}
+			continue
+		}
+
+		// Success — no retry needed.
+		if resp.StatusCode < 400 {
+			return resp, nil
+		}
+
+		// 429 Too Many Requests — retry with Retry-After if present.
+		if resp.StatusCode == http.StatusTooManyRequests {
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+			// Must drain body before retrying.
+			resp.Body.Close()
+			if attempt < cfg.MaxAttempts-1 {
+				delay := backoff(cfg, attempt, resp)
+				slog.Warn("httputil: retrying after 429",
+					"attempt", attempt+1,
+					"max", cfg.MaxAttempts,
+					"delay", delay,
+				)
+				if sleepErr := sleepWithContext(ctx, delay); sleepErr != nil {
+					return nil, sleepErr
+				}
+			}
+			continue
+		}
+
+		// 5xx — retry.
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+			resp.Body.Close()
+			if attempt < cfg.MaxAttempts-1 {
+				delay := backoff(cfg, attempt, resp)
+				slog.Warn("httputil: retrying after server error",
+					"attempt", attempt+1,
+					"max", cfg.MaxAttempts,
+					"status", resp.StatusCode,
+					"delay", delay,
+				)
+				if sleepErr := sleepWithContext(ctx, delay); sleepErr != nil {
+					return nil, sleepErr
+				}
+			}
+			continue
+		}
+
+		// 4xx (non-429) — fail fast, return response with body intact.
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("all %d attempts exhausted: %w", cfg.MaxAttempts, lastErr)
+}
+
+// backoff computes the sleep duration for the given attempt. If the response
+// contains a Retry-After header, that value takes precedence.
+func backoff(cfg RetryConfig, attempt int, resp *http.Response) time.Duration {
+	if resp != nil {
+		if ra := parseRetryAfter(resp.Header.Get("Retry-After")); ra > 0 {
+			return ra
+		}
+	}
+
+	delay := float64(cfg.BaseDelay) * math.Pow(2, float64(attempt))
+	if delay > float64(cfg.MaxDelay) {
+		delay = float64(cfg.MaxDelay)
+	}
+
+	jitter := delay * cfg.JitterFactor * (rand.Float64()*2 - 1) // ±jitter
+	delay += jitter
+	if delay < 0 {
+		delay = float64(cfg.BaseDelay)
+	}
+
+	return time.Duration(delay)
+}
+
+// parseRetryAfter parses the Retry-After header value. It supports:
+//   - seconds (e.g. "120")
+//   - HTTP-date (e.g. "Thu, 01 Dec 2024 16:00:00 GMT")
+//
+// Returns 0 if the header is empty or unparseable.
+func parseRetryAfter(val string) time.Duration {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return 0
+	}
+
+	// Try seconds first.
+	if secs, err := strconv.Atoi(val); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+
+	// Try HTTP-date.
+	if t, err := time.Parse(time.RFC1123, val); err == nil {
+		d := time.Until(t)
+		if d > 0 {
+			return d
+		}
+	}
+
+	return 0
+}
+
+// sleepWithContext sleeps for d but returns immediately if ctx is cancelled.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/httputil/retry_test.go
+++ b/internal/httputil/retry_test.go
@@ -1,0 +1,258 @@
+package httputil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDoSuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	resp, err := Do(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("GET", srv.URL, nil)
+	}, DefaultRetryConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("want body %q, got %q", "ok", string(body))
+	}
+}
+
+func TestDoRetriesOn503(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "recovered")
+	}))
+	defer srv.Close()
+
+	cfg := RetryConfig{
+		MaxAttempts:  4,
+		BaseDelay:    10 * time.Millisecond,
+		MaxDelay:     100 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	resp, err := Do(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("GET", srv.URL, nil)
+	}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("want 3 attempts, got %d", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "recovered" {
+		t.Fatalf("want body %q, got %q", "recovered", string(body))
+	}
+}
+
+func TestDoRetriesOn429WithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	cfg := RetryConfig{
+		MaxAttempts:  3,
+		BaseDelay:    10 * time.Millisecond,
+		MaxDelay:     5 * time.Second,
+		JitterFactor: 0,
+	}
+
+	start := time.Now()
+	resp, err := Do(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("GET", srv.URL, nil)
+	}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	elapsed := time.Since(start)
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("expected ~1s delay from Retry-After, got %v", elapsed)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("want 2 attempts, got %d", got)
+	}
+}
+
+func TestDoFailFastOn422(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"message":"validation failed"}`)
+	}))
+	defer srv.Close()
+
+	cfg := RetryConfig{
+		MaxAttempts:  4,
+		BaseDelay:    10 * time.Millisecond,
+		MaxDelay:     100 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	resp, err := Do(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("POST", srv.URL, nil)
+	}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("want 1 attempt (fail fast), got %d", got)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "validation failed") {
+		t.Fatalf("expected body intact, got %q", string(body))
+	}
+}
+
+func TestDoMaxAttemptsExhausted(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	cfg := RetryConfig{
+		MaxAttempts:  3,
+		BaseDelay:    10 * time.Millisecond,
+		MaxDelay:     100 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	_, err := Do(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("GET", srv.URL, nil)
+	}, cfg)
+	if err == nil {
+		t.Fatal("expected error after max attempts exhausted")
+	}
+	if !strings.Contains(err.Error(), "all 3 attempts exhausted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("want 3 attempts, got %d", got)
+	}
+}
+
+func TestDoContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := RetryConfig{
+		MaxAttempts:  10,
+		BaseDelay:    5 * time.Second, // long delay so we can cancel during it
+		MaxDelay:     30 * time.Second,
+		JitterFactor: 0,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := Do(ctx, func() (*http.Request, error) {
+			return http.NewRequest("GET", srv.URL, nil)
+		}, cfg)
+		done <- err
+	}()
+
+	// Wait for first attempt to complete, then cancel.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected context canceled, got: %v", err)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{"seconds", "120", 120 * time.Second},
+		{"one second", "1", 1 * time.Second},
+		{"empty", "", 0},
+		{"invalid", "abc", 0},
+		{"zero", "0", 0},
+		{"negative", "-5", 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseRetryAfter(tc.val)
+			if got != tc.want {
+				t.Fatalf("parseRetryAfter(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	t.Parallel()
+
+	// Use a date in the future.
+	future := time.Now().Add(5 * time.Second).UTC().Format(time.RFC1123)
+	d := parseRetryAfter(future)
+	if d < 3*time.Second || d > 6*time.Second {
+		t.Fatalf("expected ~5s from HTTP-date, got %v", d)
+	}
+}


### PR DESCRIPTION
## Summary
- **#39**: Add `httputil.Do()` retry helper with exponential backoff, jitter, Retry-After support, fail-fast on 4xx (non-429). Migrate all 8 HTTP call sites.
- **#40**: Add `findGitLabMR()` and 409 conflict handling in `CreateGitLabMR()` to match existing GitHub idempotency pattern.
- **#38**: Add pagination loops to `syncGitHub` (Link header), `syncGitLab` (X-Next-Page), and `syncSentry` (cursor-based) with 50-page safety cap.

Closes #38, closes #39, closes #40

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/httputil/...` — 8 retry helper tests pass
- [x] `go test ./internal/git/...` — 4 GitLab MR idempotency tests pass
- [x] `go test ./internal/issuesync/...` — 8 tests pass (including pagination)
- [x] `go vet ./...` — no issues