### PR TITLE
feat: add ap diff, ap logs --follow, and cost tracking

### DIFF
--- a/cmd/autopr/cli/cancel_test.go
+++ b/cmd/autopr/cli/cancel_test.go
@@ -39,7 +39,7 @@ func TestCancelJobByIDHappyPath(t *testing.T) {
 	if err := store.UpdateJobField(ctx, jobID, "worktree_path", filepath.Join(tmp, "wt")); err != nil {
 		t.Fatalf("set worktree path: %v", err)
 	}
-	if _, err := store.CreateSession(ctx, jobID, "plan", 0, "codex"); err != nil {
+	if _, err := store.CreateSession(ctx, jobID, "plan", 0, "codex", ""); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
 

--- a/cmd/autopr/cli/diff.go
+++ b/cmd/autopr/cli/diff.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"autopr/internal/git"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	diffStat    bool
+	diffNoColor bool
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff <job-id>",
+	Short: "Show the git diff for a job's changes against the base branch",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDiff,
+}
+
+func init() {
+	diffCmd.Flags().BoolVar(&diffStat, "stat", false, "show diffstat summary only")
+	diffCmd.Flags().BoolVar(&diffNoColor, "no-color", false, "disable ANSI colors")
+	rootCmd.AddCommand(diffCmd)
+}
+
+func runDiff(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	store, err := openStore(cfg)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	jobID, err := resolveJob(store, args[0])
+	if err != nil {
+		return err
+	}
+
+	job, err := store.GetJob(cmd.Context(), jobID)
+	if err != nil {
+		return err
+	}
+
+	if job.State == "queued" {
+		return fmt.Errorf("job has not started yet")
+	}
+	if job.WorktreePath == "" {
+		return fmt.Errorf("no worktree available (job may have been cleaned up)")
+	}
+	if _, err := os.Stat(job.WorktreePath); os.IsNotExist(err) {
+		return fmt.Errorf("worktree directory not found (run `ap cleanup` removed it?)")
+	}
+
+	baseBranch := "main"
+	if p, ok := cfg.ProjectByName(job.ProjectName); ok && p.BaseBranch != "" {
+		baseBranch = p.BaseBranch
+	}
+
+	if diffStat {
+		return runDiffStat(cmd, job.WorktreePath, baseBranch, jobID)
+	}
+
+	diffText, err := git.DiffAgainstBase(cmd.Context(), job.WorktreePath, baseBranch)
+	if err != nil {
+		return err
+	}
+
+	if diffText == "" {
+		fmt.Println("(no changes)")
+		return nil
+	}
+
+	if jsonOut {
+		printJSON(map[string]any{
+			"job_id": jobID,
+			"diff":   diffText,
+		})
+		return nil
+	}
+
+	if diffNoColor {
+		fmt.Print(diffText)
+		return nil
+	}
+
+	// Print with ANSI colors.
+	for _, line := range strings.Split(diffText, "\n") {
+		fmt.Println(colorDiffLine(line))
+	}
+	return nil
+}
+
+func runDiffStat(cmd *cobra.Command, worktreePath, baseBranch, jobID string) error {
+	stat, err := git.DiffStatAgainstBase(cmd.Context(), worktreePath, baseBranch)
+	if err != nil {
+		return err
+	}
+
+	if stat == "" {
+		fmt.Println("(no changes)")
+		return nil
+	}
+
+	if jsonOut {
+		printJSON(map[string]any{
+			"job_id": jobID,
+			"stat":   stat,
+		})
+		return nil
+	}
+
+	fmt.Print(stat)
+	return nil
+}
+
+// colorDiffLine applies ANSI color codes to a diff line for CLI output.
+func colorDiffLine(line string) string {
+	const (
+		reset = "\033[0m"
+		red   = "\033[31m"
+		green = "\033[32m"
+		cyan  = "\033[36m"
+		bold  = "\033[1m"
+	)
+	switch {
+	case strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "--- "):
+		return bold + line + reset
+	case strings.HasPrefix(line, "+"):
+		return green + line + reset
+	case strings.HasPrefix(line, "-"):
+		return red + line + reset
+	case strings.HasPrefix(line, "@@"):
+		return cyan + line + reset
+	case strings.HasPrefix(line, "diff --git"):
+		return bold + line + reset
+	default:
+		return line
+	}
+}

--- a/cmd/autopr/cli/logs.go
+++ b/cmd/autopr/cli/logs.go
@@ -1,13 +1,22 @@
 package cli
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"os/signal"
 	"strings"
+	"time"
 
+	"autopr/internal/cost"
 	"autopr/internal/db"
 
 	"github.com/spf13/cobra"
 )
+
+var logsFollow bool
 
 var logsCmd = &cobra.Command{
 	Use:   "logs <job-id>",
@@ -17,6 +26,7 @@ var logsCmd = &cobra.Command{
 }
 
 func init() {
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "stream live LLM output")
 	rootCmd.AddCommand(logsCmd)
 }
 
@@ -53,6 +63,8 @@ func runLogs(cmd *cobra.Command, args []string) error {
 
 	issue, issueErr := store.GetIssueByAPID(cmd.Context(), job.AutoPRIssueID)
 
+	tokenSummary, _ := store.AggregateTokensByJob(cmd.Context(), jobID)
+
 	if jsonOut {
 		payload := map[string]any{
 			"job":       job,
@@ -61,6 +73,17 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		}
 		if issueErr == nil {
 			payload["issue"] = issue
+		}
+		if tokenSummary.SessionCount > 0 {
+			payload["cost_summary"] = map[string]any{
+				"sessions":      tokenSummary.SessionCount,
+				"input_tokens":  tokenSummary.TotalInputTokens,
+				"output_tokens": tokenSummary.TotalOutputTokens,
+				"duration_ms":   tokenSummary.TotalDurationMS,
+				"estimated_cost": cost.Calculate(tokenSummary.Provider,
+					tokenSummary.TotalInputTokens, tokenSummary.TotalOutputTokens),
+				"provider": tokenSummary.Provider,
+			}
 		}
 		printJSON(payload)
 		return nil
@@ -123,7 +146,6 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		fmt.Println("\n=== Artifacts ===")
 		for _, a := range artifacts {
 			fmt.Printf("\n--- %s (iter %d) ---\n", a.Kind, a.Iteration)
-			// Show first 500 chars of content.
 			content := a.Content
 			if len(content) > 500 {
 				content = content[:500] + "\n... (truncated)"
@@ -132,5 +154,212 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Cost summary.
+	if tokenSummary.SessionCount > 0 {
+		estCost := cost.Calculate(tokenSummary.Provider, tokenSummary.TotalInputTokens, tokenSummary.TotalOutputTokens)
+		durationSec := float64(tokenSummary.TotalDurationMS) / 1000.0
+		fmt.Println()
+		fmt.Println("=== Cost Summary ===")
+		fmt.Printf("Sessions: %d  Input: %d tokens  Output: %d tokens\n",
+			tokenSummary.SessionCount, tokenSummary.TotalInputTokens, tokenSummary.TotalOutputTokens)
+		fmt.Printf("Estimated cost: %s (%s @ %s)\n",
+			cost.FormatUSD(estCost), tokenSummary.Provider, cost.FormatRate(tokenSummary.Provider))
+		fmt.Printf("Total duration: %.1fs\n", durationSec)
+	}
+
+	// Follow mode.
+	if logsFollow {
+		return followJob(cmd.Context(), store, jobID, job)
+	}
+
 	return nil
+}
+
+// isTerminalState returns true if the job state is terminal.
+func isTerminalState(state string) bool {
+	switch state {
+	case "ready", "approved", "rejected", "failed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func followJob(ctx context.Context, store *db.Store, jobID string, job db.Job) error {
+	if isTerminalState(job.State) {
+		fmt.Println("\nJob already completed.")
+		return nil
+	}
+
+	fmt.Println("\n--- Following live output (Ctrl+C to stop) ---")
+
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	for {
+		session, err := store.GetRunningSessionForJob(ctx, jobID)
+		if err != nil {
+			return err
+		}
+
+		if session != nil && session.JSONLPath != "" {
+			if err := tailJSONL(ctx, store, jobID, session); err != nil {
+				if ctx.Err() != nil {
+					fmt.Println("\nStopped following.")
+					return nil
+				}
+				return err
+			}
+		}
+
+		// Check if job is done.
+		job, err = store.GetJob(ctx, jobID)
+		if err != nil {
+			return err
+		}
+		if isTerminalState(job.State) {
+			fmt.Printf("\nJob reached state: %s\n", db.DisplayState(job.State, job.PRMergedAt, job.PRClosedAt))
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			fmt.Println("\nStopped following.")
+			return nil
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// tailJSONL tails a JSONL file and prints live LLM output until the session
+// is no longer running or the file stops growing.
+//
+// bufio.Scanner cannot resume after EOF, so we track the file offset manually
+// and create a fresh scanner on each poll cycle.
+func tailJSONL(ctx context.Context, store *db.Store, jobID string, session *db.LLMSession) error {
+	f, err := os.Open(session.JSONLPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File not yet created, wait a bit.
+			time.Sleep(500 * time.Millisecond)
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	// Start tailing from end of file.
+	offset, err := f.Seek(0, 2)
+	if err != nil {
+		return err
+	}
+
+	idleCount := 0
+	step := db.DisplayStep(session.Step)
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Seek to our last known position and create a fresh scanner so
+		// new data appended after a previous EOF is picked up.
+		if _, err := f.Seek(offset, 0); err != nil {
+			return err
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+		scanned := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			printJSONLLine(step, line)
+			scanned = true
+		}
+
+		// Record where we stopped so the next iteration resumes here.
+		newOffset, seekErr := f.Seek(0, 1)
+		if seekErr == nil {
+			offset = newOffset
+		}
+
+		if scanned {
+			idleCount = 0
+			continue // Drain all available lines before sleeping.
+		}
+
+		// No new lines — check if session is still running.
+		idleCount++
+		if idleCount > 10 { // 10 * 500ms = 5s idle
+			sess, err := store.GetRunningSessionForJob(ctx, jobID)
+			if err != nil {
+				return err
+			}
+			if sess == nil || sess.ID != session.ID {
+				return nil // Session ended or changed
+			}
+			idleCount = 0
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+type jsonlMessage struct {
+	Type    string      `json:"type"`
+	Message jsonlAssist `json:"message,omitempty"`
+	Result  string      `json:"result,omitempty"`
+	Item    *jsonlItem  `json:"item,omitempty"`
+	Usage   *jsonlUsage `json:"usage,omitempty"`
+}
+
+type jsonlAssist struct {
+	Content []jsonlBlock `json:"content,omitempty"`
+	Usage   jsonlUsage   `json:"usage,omitempty"`
+}
+
+type jsonlBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type jsonlItem struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type jsonlUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+func printJSONLLine(step, line string) {
+	var msg jsonlMessage
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		return
+	}
+
+	switch {
+	case msg.Type == "assistant" && msg.Message.Content != nil:
+		for _, block := range msg.Message.Content {
+			if block.Type == "text" && block.Text != "" {
+				fmt.Printf("[%s] %s\n", step, block.Text)
+			}
+		}
+	case msg.Type == "result" && msg.Result != "":
+		fmt.Printf("[%s] %s\n", step, msg.Result)
+	case msg.Type == "item.completed" && msg.Item != nil:
+		if msg.Item.Type == "agent_message" && msg.Item.Text != "" {
+			fmt.Printf("[%s] %s\n", step, msg.Item.Text)
+		}
+	case msg.Type == "turn.completed" && msg.Usage != nil:
+		fmt.Printf("[%s] tokens: %d in / %d out\n", step, msg.Usage.InputTokens, msg.Usage.OutputTokens)
+	}
 }

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -1,0 +1,40 @@
+package cost
+
+import "fmt"
+
+// Rate holds per-1M-token pricing in USD.
+type Rate struct {
+	Input  float64 // USD per 1M input tokens
+	Output float64 // USD per 1M output tokens
+}
+
+// DefaultRates contains hardcoded per-provider pricing.
+var DefaultRates = map[string]Rate{
+	"claude": {Input: 3.00, Output: 15.00},
+	"codex":  {Input: 3.00, Output: 12.00},
+}
+
+// Calculate returns the estimated cost in USD for the given token counts.
+func Calculate(provider string, inputTokens, outputTokens int) float64 {
+	rate, ok := DefaultRates[provider]
+	if !ok {
+		return 0
+	}
+	inCost := float64(inputTokens) / 1_000_000 * rate.Input
+	outCost := float64(outputTokens) / 1_000_000 * rate.Output
+	return inCost + outCost
+}
+
+// FormatUSD formats a cost as a dollar string (e.g. "$0.42" or "$1.23").
+func FormatUSD(cost float64) string {
+	return fmt.Sprintf("$%.2f", cost)
+}
+
+// FormatRate returns a display string for a provider's rate (e.g. "$3.00/$15.00 per 1M tokens").
+func FormatRate(provider string) string {
+	rate, ok := DefaultRates[provider]
+	if !ok {
+		return "unknown pricing"
+	}
+	return fmt.Sprintf("$%.2f/$%.2f per 1M tokens", rate.Input, rate.Output)
+}

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -1,0 +1,93 @@
+package cost
+
+import (
+	"testing"
+)
+
+func TestCalculate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		in, out  int
+		wantMin  float64
+		wantMax  float64
+	}{
+		{
+			name:     "claude zero tokens",
+			provider: "claude",
+			in:       0, out: 0,
+			wantMin: 0, wantMax: 0,
+		},
+		{
+			name:     "claude 1M input 1M output",
+			provider: "claude",
+			in:       1_000_000, out: 1_000_000,
+			wantMin: 18.0, wantMax: 18.0, // $3 + $15
+		},
+		{
+			name:     "codex 1M input 1M output",
+			provider: "codex",
+			in:       1_000_000, out: 1_000_000,
+			wantMin: 15.0, wantMax: 15.0, // $3 + $12
+		},
+		{
+			name:     "unknown provider",
+			provider: "gpt5",
+			in:       1_000_000, out: 1_000_000,
+			wantMin: 0, wantMax: 0,
+		},
+		{
+			name:     "claude small tokens",
+			provider: "claude",
+			in:       45230, out: 12890,
+			wantMin: 0.32, wantMax: 0.34,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Calculate(tc.provider, tc.in, tc.out)
+			if got < tc.wantMin || got > tc.wantMax {
+				t.Errorf("Calculate(%q, %d, %d) = %f, want [%f, %f]",
+					tc.provider, tc.in, tc.out, got, tc.wantMin, tc.wantMax)
+			}
+		})
+	}
+}
+
+func TestFormatUSD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input float64
+		want  string
+	}{
+		{0, "$0.00"},
+		{0.42, "$0.42"},
+		{1.234, "$1.23"},
+		{100.5, "$100.50"},
+	}
+
+	for _, tc := range tests {
+		got := FormatUSD(tc.input)
+		if got != tc.want {
+			t.Errorf("FormatUSD(%f) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestFormatRate(t *testing.T) {
+	t.Parallel()
+
+	got := FormatRate("claude")
+	if got != "$3.00/$15.00 per 1M tokens" {
+		t.Errorf("FormatRate(claude) = %q", got)
+	}
+
+	got = FormatRate("unknown")
+	if got != "unknown pricing" {
+		t.Errorf("FormatRate(unknown) = %q", got)
+	}
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,0 +1,36 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// DiffAgainstBase returns the raw diff of a worktree against origin/<baseBranch>.
+// It runs `git add -N .` first so untracked files appear in the diff output.
+func DiffAgainstBase(ctx context.Context, worktreePath, baseBranch string) (string, error) {
+	// Mark untracked files as intent-to-add so they appear in diff output.
+	addN := exec.CommandContext(ctx, "git", "add", "-N", ".")
+	addN.Dir = worktreePath
+	_ = addN.Run()
+
+	out, err := runGitOutput(ctx, worktreePath, "diff", fmt.Sprintf("origin/%s", baseBranch))
+	if err != nil {
+		return "", fmt.Errorf("diff against origin/%s: %w", baseBranch, err)
+	}
+	return out, nil
+}
+
+// DiffStatAgainstBase returns the --stat summary of a worktree against origin/<baseBranch>.
+func DiffStatAgainstBase(ctx context.Context, worktreePath, baseBranch string) (string, error) {
+	// Mark untracked files as intent-to-add so they appear in diff output.
+	addN := exec.CommandContext(ctx, "git", "add", "-N", ".")
+	addN.Dir = worktreePath
+	_ = addN.Run()
+
+	out, err := runGitOutput(ctx, worktreePath, "diff", "--stat", fmt.Sprintf("origin/%s", baseBranch))
+	if err != nil {
+		return "", fmt.Errorf("diff stat against origin/%s: %w", baseBranch, err)
+	}
+	return out, nil
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -8,8 +8,9 @@ type Provider interface {
 	Name() string
 
 	// Run invokes the LLM CLI tool in the given workDir with the given prompt.
+	// jsonlPath is the pre-determined path for the JSONL session file.
 	// Returns the response with token counts and timing.
-	Run(ctx context.Context, workDir, prompt string) (Response, error)
+	Run(ctx context.Context, workDir, prompt, jsonlPath string) (Response, error)
 }
 
 // Response captures the output of an LLM invocation.

--- a/internal/pipeline/pipeline_cancel_test.go
+++ b/internal/pipeline/pipeline_cancel_test.go
@@ -21,7 +21,7 @@ type blockingProvider struct {
 
 func (p *blockingProvider) Name() string { return "codex" }
 
-func (p *blockingProvider) Run(ctx context.Context, workDir, prompt string) (llm.Response, error) {
+func (p *blockingProvider) Run(ctx context.Context, workDir, prompt, jsonlPath string) (llm.Response, error) {
 	p.once.Do(func() { close(p.started) })
 	<-ctx.Done()
 	return llm.Response{}, ctx.Err()
@@ -31,7 +31,7 @@ type neverCalledProvider struct{}
 
 func (p *neverCalledProvider) Name() string { return "codex" }
 
-func (p *neverCalledProvider) Run(ctx context.Context, workDir, prompt string) (llm.Response, error) {
+func (p *neverCalledProvider) Run(ctx context.Context, workDir, prompt, jsonlPath string) (llm.Response, error) {
 	return llm.Response{}, errors.New("provider should not be called")
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -17,7 +17,7 @@ type stubProvider struct {
 
 func (p stubProvider) Name() string { return "codex" }
 
-func (p stubProvider) Run(ctx context.Context, workDir, prompt string) (llm.Response, error) {
+func (p stubProvider) Run(ctx context.Context, workDir, prompt, jsonlPath string) (llm.Response, error) {
 	return p.run(ctx, workDir, prompt)
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -227,24 +227,14 @@ func (m Model) fetchDiff() tea.Msg {
 		baseBranch = p.BaseBranch
 	}
 
-	// Mark untracked files as intent-to-add so they appear in diff output.
-	addN := exec.CommandContext(context.Background(), "git", "add", "-N", ".")
-	addN.Dir = job.WorktreePath
-	_ = addN.Run()
-
-	// Diff against origin base branch to show all job changes:
-	// committed, staged, unstaged, and newly created files.
-	cmd := exec.CommandContext(context.Background(),
-		"git", "diff", fmt.Sprintf("origin/%s", baseBranch))
-	cmd.Dir = job.WorktreePath
-	out, err := cmd.Output()
+	out, err := git.DiffAgainstBase(context.Background(), job.WorktreePath, baseBranch)
 	if err != nil {
 		return diffMsg{jobID: job.ID, lines: []string{fmt.Sprintf("(git diff error: %v)", err)}}
 	}
-	if len(out) == 0 {
+	if out == "" {
 		return diffMsg{jobID: job.ID, lines: []string{"(no changes)"}}
 	}
-	return diffMsg{jobID: job.ID, lines: strings.Split(string(out), "\n")}
+	return diffMsg{jobID: job.ID, lines: strings.Split(out, "\n")}
 }
 
 // openInEditor opens the worktree directory in the user's preferred editor.


### PR DESCRIPTION
## Summary
- **`ap diff <job-id>`** (#30): Show git diff for a job's changes against base branch, with `--stat`, `--no-color`, and `--json` flags
- **`ap logs --follow`** (#28): Stream live LLM output from running session JSONL files with proper EOF resume handling
- **Cost tracking** (#29): Aggregate token costs displayed in `ap logs` (cost summary section) and `ap list --cost` column

## Details
- Extracts shared diff logic from TUI into `internal/git` package
- Refactors JSONL path lifecycle: generated in pipeline, stored at session creation, discoverable for live tailing
- Adds `internal/cost` package with per-provider pricing (claude, codex)
- New DB queries: `AggregateTokensByJob`, `AggregateTokensForJobs`, `GetRunningSessionForJob`
- Deterministic provider selection via correlated subquery for mixed-provider jobs

## Test plan
- [x] `go test ./...` — all 14 packages pass
- [x] Unit tests for cost calculation, USD formatting, rate display
- [x] DB tests for token aggregation (single and batch), mixed-provider determinism, running session lookup, JSONL path storage
- [x] CLI cancel tests updated for new `CreateSession` signature
- [x] Pipeline cancel tests updated for new provider interface

Closes #28, #29, #30