### PR TITLE
feat: inject human_notes from ap retry into LLM prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Prompt templates support these placeholders:
 | `{{body}}` | Issue body (sanitized) |
 | `{{plan}}` | Plan artifact content |
 | `{{review_feedback}}` | Previous review + test output |
+| `{{human_notes}}` | Human guidance from `ap retry -n` (plan step only) |
 
 ## Health Check
 

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -23,6 +23,8 @@ Title: {{title}}
 {{body}}
 </issue>
 
+{{human_notes}}
+
 Create a step-by-step implementation plan that includes:
 1. Which files need to be modified or created
 2. The specific changes needed in each file
@@ -87,9 +89,15 @@ func (r *Runner) runPlan(ctx context.Context, jobID string, issue db.Issue, proj
 		}
 	}
 
+	humanNotes := ""
+	if job.HumanNotes != "" {
+		humanNotes = fmt.Sprintf("<human_notes>\n%s\n</human_notes>", job.HumanNotes)
+	}
+
 	prompt := BuildPrompt(template, map[string]string{
-		"title": issue.Title,
-		"body":  SanitizeIssueContent(issue.Body),
+		"title":       issue.Title,
+		"body":        SanitizeIssueContent(issue.Body),
+		"human_notes": humanNotes,
 	})
 
 	resp, err := r.invokeProvider(ctx, jobID, "plan", job.Iteration, workDir, prompt)


### PR DESCRIPTION
## Summary
- When retrying a job with `ap retry -n "notes"`, the notes are now injected into the plan step prompt as `<human_notes>` tags
- Previously, `human_notes` were stored in the DB but never read by the pipeline — the LLM had no idea why it was being retried
- Reject reason (`ap reject -r`) remains audit-only (stored in `reject_reason` column, not passed to LLM)

## Changes
- `internal/pipeline/steps.go`: Conditionally wrap `job.HumanNotes` in `<human_notes>` tags and pass as `{{human_notes}}` to `BuildPrompt` in `runPlan`
- `README.md`: Document `{{human_notes}}` placeholder in prompt template table

## Test plan
- [x] All existing tests pass
- [ ] Retry a job with `-n "fix X"` and verify the plan prompt includes the notes