### PR TITLE
[AutoPR] bug: Pipeline fails when stale worktree directory exists from a previous run

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,8 +2,11 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 // CloneForJob clones the remote repo into destPath and creates a job branch
@@ -11,6 +14,11 @@ import (
 // tools (e.g. codex) may run `git init` in the working directory, which
 // destroys worktree .git link files but is a no-op on a .git directory.
 func CloneForJob(ctx context.Context, repoURL, token, destPath, branchName, baseBranch string) error {
+	destPath, err := prepareCloneDestination(destPath)
+	if err != nil {
+		return fmt.Errorf("prepare clone destination: %w", err)
+	}
+
 	authURL := injectToken(repoURL, token)
 
 	// Clone from the remote. For repos that already have a local bare cache,
@@ -26,6 +34,41 @@ func CloneForJob(ctx context.Context, repoURL, token, destPath, branchName, base
 	}
 
 	return nil
+}
+
+func prepareCloneDestination(destPath string) (string, error) {
+	if strings.TrimSpace(destPath) == "" {
+		return "", fmt.Errorf("destination path is empty")
+	}
+
+	cleanPath := filepath.Clean(destPath)
+	if cleanPath == "." || cleanPath == ".." || isFilesystemRoot(cleanPath) {
+		return "", fmt.Errorf("destination path %q is unsafe", destPath)
+	}
+
+	if _, err := os.Stat(cleanPath); err == nil {
+		if err := os.RemoveAll(cleanPath); err != nil {
+			return "", fmt.Errorf("remove stale worktree %q: %w", cleanPath, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat worktree destination %q: %w", cleanPath, err)
+	}
+
+	parent := filepath.Dir(cleanPath)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("create worktree parent %q: %w", parent, err)
+	}
+
+	return cleanPath, nil
+}
+
+func isFilesystemRoot(path string) bool {
+	if !filepath.IsAbs(path) {
+		return false
+	}
+	volume := filepath.VolumeName(path)
+	root := volume + string(os.PathSeparator)
+	return path == root
 }
 
 // RemoveJobDir removes a job's cloned working directory.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,115 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCloneForJob_RemovesStaleDestinationAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+	remote := createRemoteWithMainBranch(t, tmp)
+
+	destPath := filepath.Join(tmp, "repos", "worktrees", "ap-job-123")
+	if err := os.MkdirAll(destPath, 0o755); err != nil {
+		t.Fatalf("mkdir stale destination: %v", err)
+	}
+	marker := filepath.Join(destPath, "stale-marker.txt")
+	if err := os.WriteFile(marker, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale marker: %v", err)
+	}
+
+	branchName := "autopr/job-123"
+	if err := CloneForJob(ctx, remote, "", destPath, branchName, "main"); err != nil {
+		t.Fatalf("clone for job: %v", err)
+	}
+
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("expected stale marker to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destPath, ".git")); err != nil {
+		t.Fatalf("expected cloned repo at destination: %v", err)
+	}
+
+	currentBranch, err := runGitOutput(ctx, destPath, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("read current branch: %v", err)
+	}
+	if got := strings.TrimSpace(currentBranch); got != branchName {
+		t.Fatalf("expected branch %q, got %q", branchName, got)
+	}
+}
+
+func TestCloneForJob_CreatesMissingParentDir(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+	remote := createRemoteWithMainBranch(t, tmp)
+
+	destPath := filepath.Join(tmp, "missing", "nested", "worktrees", "ap-job-456")
+	if err := CloneForJob(ctx, remote, "", destPath, "autopr/job-456", "main"); err != nil {
+		t.Fatalf("clone for job: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(destPath, ".git")); err != nil {
+		t.Fatalf("expected destination to be cloned: %v", err)
+	}
+}
+
+func TestCloneForJob_RejectsUnsafeDestination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		destPath        string
+		wantErrContains string
+	}{
+		{name: "empty", destPath: "", wantErrContains: "empty"},
+		{name: "dot", destPath: ".", wantErrContains: "unsafe"},
+		{name: "dot dot", destPath: "..", wantErrContains: "unsafe"},
+		{name: "root", destPath: string(os.PathSeparator), wantErrContains: "unsafe"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := CloneForJob(context.Background(), "https://example.com/repo.git", "", tc.destPath, "autopr/job", "main")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrContains) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErrContains, err)
+			}
+		})
+	}
+}
+
+func createRemoteWithMainBranch(t *testing.T, tmp string) string {
+	t.Helper()
+
+	remote := filepath.Join(tmp, "remote.git")
+	runGitCmd(t, "", "init", "--bare", remote)
+
+	seed := filepath.Join(tmp, "seed")
+	runGitCmd(t, "", "init", seed)
+	runGitCmd(t, seed, "config", "user.email", "test@example.com")
+	runGitCmd(t, seed, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGitCmd(t, seed, "add", "README.md")
+	runGitCmd(t, seed, "commit", "-m", "init")
+	runGitCmd(t, seed, "branch", "-M", "main")
+	runGitCmd(t, seed, "remote", "add", "origin", remote)
+	runGitCmd(t, seed, "push", "-u", "origin", "main")
+
+	return remote
+}

--- a/internal/pipeline/pipeline_clone_test.go
+++ b/internal/pipeline/pipeline_clone_test.go
@@ -1,0 +1,149 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"autopr/internal/config"
+	"autopr/internal/db"
+	"autopr/internal/llm"
+)
+
+func TestRun_StaleWorktreeDirectoryIsReplacedBeforeClone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+
+	store, err := db.Open(filepath.Join(tmp, "autopr.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer store.Close()
+
+	remote := createBareRemoteWithMain(t, tmp)
+	cfg := &config.Config{
+		ReposRoot: filepath.Join(tmp, "repos"),
+		LLM:       config.LLMConfig{Provider: "codex"},
+		Projects: []config.ProjectConfig{{
+			Name:       "myproject",
+			RepoURL:    remote,
+			BaseBranch: "main",
+			TestCmd:    "true",
+			GitHub:     &config.ProjectGitHub{Owner: "org", Repo: "repo"},
+		}},
+	}
+
+	issueID, err := store.UpsertIssue(ctx, db.IssueUpsert{
+		ProjectName:   "myproject",
+		Source:        "github",
+		SourceIssueID: "101",
+		Title:         "stale clone path retry",
+		Body:          "retry should clean stale worktree",
+		URL:           "https://github.com/org/repo/issues/101",
+		State:         "open",
+	})
+	if err != nil {
+		t.Fatalf("upsert issue: %v", err)
+	}
+
+	jobID, err := store.CreateJob(ctx, issueID, "myproject", 3)
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	claimedID, err := store.ClaimJob(ctx)
+	if err != nil {
+		t.Fatalf("claim job: %v", err)
+	}
+	if claimedID != jobID {
+		t.Fatalf("claimed job %q, want %q", claimedID, jobID)
+	}
+
+	stalePath := filepath.Join(cfg.ReposRoot, "worktrees", jobID)
+	if err := os.MkdirAll(stalePath, 0o755); err != nil {
+		t.Fatalf("mkdir stale path: %v", err)
+	}
+	marker := filepath.Join(stalePath, "stale-marker.txt")
+	if err := os.WriteFile(marker, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale marker: %v", err)
+	}
+
+	var callCount int
+	provider := stubProvider{
+		run: func(ctx context.Context, workDir, prompt string) (llm.Response, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				return llm.Response{Text: "Plan"}, nil
+			case 2:
+				return llm.Response{Text: "Implemented"}, nil
+			case 3:
+				return llm.Response{Text: "APPROVED"}, nil
+			default:
+				return llm.Response{}, nil
+			}
+		},
+	}
+
+	runner := New(store, provider, cfg)
+	if err := runner.Run(ctx, jobID); err != nil {
+		t.Fatalf("run pipeline: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != "ready" {
+		t.Fatalf("expected ready state, got %q", job.State)
+	}
+
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("expected stale marker to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stalePath, ".git")); err != nil {
+		t.Fatalf("expected cloned repo at stale path: %v", err)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 provider calls, got %d", callCount)
+	}
+}
+
+func createBareRemoteWithMain(t *testing.T, root string) string {
+	t.Helper()
+
+	remote := filepath.Join(root, "remote.git")
+	runGitCmdLocal(t, "", "init", "--bare", remote)
+
+	seed := filepath.Join(root, "seed")
+	runGitCmdLocal(t, "", "init", seed)
+	runGitCmdLocal(t, seed, "config", "user.email", "test@example.com")
+	runGitCmdLocal(t, seed, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGitCmdLocal(t, seed, "add", "README.md")
+	runGitCmdLocal(t, seed, "commit", "-m", "initial commit")
+	runGitCmdLocal(t, seed, "branch", "-M", "main")
+	runGitCmdLocal(t, seed, "remote", "add", "origin", remote)
+	runGitCmdLocal(t, seed, "push", "-u", "origin", "main")
+
+	return remote
+}
+
+func runGitCmdLocal(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/67

**Issue:** bug: Pipeline fails when stale worktree directory exists from a previous run

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `052c7025`_
