### PR TITLE
fix: poll DB for queued jobs so ap retry works without restart

### DIFF
--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"autopr/internal/db"
 	"autopr/internal/pipeline"
@@ -48,6 +49,9 @@ func (p *Pool) worker(ctx context.Context, id int) {
 	defer p.wg.Done()
 	slog.Debug("worker started", "id", id)
 
+	poll := time.NewTicker(5 * time.Second)
+	defer poll.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -58,6 +62,8 @@ func (p *Pool) worker(ctx context.Context, id int) {
 				return
 			}
 			p.processJob(ctx, id, notifiedJobID)
+		case <-poll.C:
+			p.processJob(ctx, id, "")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Workers now poll the DB every 5 seconds via `ClaimJob()` to pick up jobs queued by external means (e.g. `ap retry`)
- Previously, retried jobs sat in `queued` forever because they bypassed the `jobCh` channel
- Minimal change: 4 lines added to `internal/worker/pool.go`

## Test plan
- [x] `go build ./internal/worker/` compiles
- [x] `go test ./...` all tests pass
- [ ] Manual: start daemon, run `ap retry <job>`, confirm pickup within ~5s