### PR TITLE
docs: use GitHub Pages URL for job state diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ session detail and diff views to avoid content jumping.
 
 ## 8. Job States
 
-See the **[interactive job state diagram](docs/job_state.html)** — hover, click, and filter by actor (daemon / user / LLM / config).
+See the **[interactive job state diagram](https://ashwath-ramesh.github.io/autopr/job_state.html)** — hover, click, and filter by actor (daemon / user / LLM / config).
 
 - **Actors:** `daemon` (automatic orchestration), `llm` (AI review decision), `user` (CLI action), `config` (auto_pr).
 - **Terminal states:** `approved` is final; `failed`, `rejected`, and `cancelled` are retryable via `ap retry`.


### PR DESCRIPTION
## Summary
- Updated the job state diagram link in README to use the GitHub Pages URL (`ashwath-ramesh.github.io`) instead of a relative path
- The relative path showed raw HTML code on GitHub; the Pages URL renders it as an interactive webpage

## Test plan
- [ ] Verify link in README renders the interactive diagram in browser