### PR TITLE
fix: add include_labels gating to GitLab sync and webhook

### DIFF
--- a/autopr.toml.example
+++ b/autopr.toml.example
@@ -46,6 +46,7 @@ base_branch = "main"
   [projects.gitlab]
   base_url = "https://gitlab.com"
   project_id = "12345"
+  # include_labels = ["autopr"]  # optional: ANY match; empty means all open issues
 
   # [projects.github]
   # owner = "myorg"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,8 +148,9 @@ type ProjectConfig struct {
 }
 
 type ProjectGitLab struct {
-	BaseURL   string `toml:"base_url"`
-	ProjectID string `toml:"project_id"`
+	BaseURL       string   `toml:"base_url"`
+	ProjectID     string   `toml:"project_id"`
+	IncludeLabels []string `toml:"include_labels"`
 }
 
 type ProjectGitHub struct {
@@ -356,6 +357,13 @@ func validate(cfg *Config) error {
 				return fmt.Errorf("project %q github.include_labels: %w", p.Name, err)
 			}
 			cfg.Projects[i].GitHub.IncludeLabels = normalized
+		}
+		if p.GitLab != nil {
+			normalized, err := normalizeLabels(p.GitLab.IncludeLabels)
+			if err != nil {
+				return fmt.Errorf("project %q gitlab.include_labels: %w", p.Name, err)
+			}
+			cfg.Projects[i].GitLab.IncludeLabels = normalized
 		}
 	}
 	return nil

--- a/internal/issuesync/eligibility.go
+++ b/internal/issuesync/eligibility.go
@@ -11,7 +11,7 @@ type issueEligibility struct {
 	EvaluatedAt string
 }
 
-func evaluateGitHubIssueEligibility(includeLabels, issueLabels []string, evaluatedAt time.Time) issueEligibility {
+func evaluateIssueEligibility(includeLabels, issueLabels []string, evaluatedAt time.Time) issueEligibility {
 	required := normalizeLabelSet(includeLabels)
 	if evaluatedAt.IsZero() {
 		evaluatedAt = time.Now().UTC()

--- a/internal/issuesync/github.go
+++ b/internal/issuesync/github.go
@@ -132,7 +132,7 @@ func (s *Syncer) syncGitHubIssues(ctx context.Context, p *config.ProjectConfig, 
 			labels = append(labels, l.Name)
 		}
 
-		eligibility := evaluateGitHubIssueEligibility(includeLabels, labels, time.Now().UTC())
+		eligibility := evaluateIssueEligibility(includeLabels, labels, time.Now().UTC())
 		eligible := eligibility.Eligible
 		state := "open"
 		if issue.State == "closed" {

--- a/internal/issuesync/github_test.go
+++ b/internal/issuesync/github_test.go
@@ -45,7 +45,7 @@ func TestEvaluateGitHubIssueEligibility(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := evaluateGitHubIssueEligibility(tc.includeLabels, tc.issueLabels, now)
+			got := evaluateIssueEligibility(tc.includeLabels, tc.issueLabels, now)
 			if got.Eligible != tc.wantEligible {
 				t.Fatalf("eligible: want %v got %v", tc.wantEligible, got.Eligible)
 			}

--- a/internal/issuesync/gitlab_test.go
+++ b/internal/issuesync/gitlab_test.go
@@ -1,0 +1,143 @@
+package issuesync
+
+import (
+	"context"
+	"testing"
+
+	"autopr/internal/config"
+)
+
+func TestSyncGitLabIssuesLabelGateSkipsUnlabeled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitLab: "test-token"},
+		Daemon: config.DaemonConfig{MaxIterations: 3},
+	}
+	project := &config.ProjectConfig{
+		Name: "gl-project",
+		GitLab: &config.ProjectGitLab{
+			BaseURL:       "https://gitlab.com",
+			ProjectID:     "99",
+			IncludeLabels: []string{"autopr"},
+		},
+	}
+	syncer := NewSyncer(cfg, store, make(chan string, 8))
+
+	// Simulate a page of GitLab issues — none have the "autopr" label.
+	issues := []gitlabIssue{
+		{
+			IID:         1,
+			Title:       "unlabeled issue",
+			Description: "body",
+			WebURL:      "https://gitlab.com/group/repo/-/issues/1",
+			Labels:      []string{"bug"},
+			UpdatedAt:   "2026-02-17T10:00:00Z",
+		},
+	}
+
+	syncer.syncGitLabPage(ctx, project, issues)
+
+	// Issue should be stored but ineligible.
+	issue := getIssueBySourceID(t, ctx, store, "gl-project", "gitlab", "1")
+	if issue.Eligible {
+		t.Fatalf("expected issue to be ineligible, got eligible")
+	}
+	if issue.SkipReason != "missing required labels: autopr" {
+		t.Fatalf("unexpected skip reason: %q", issue.SkipReason)
+	}
+
+	// No job should be created.
+	if countJobs(t, ctx, store) != 0 {
+		t.Fatalf("expected no jobs for unlabeled gitlab issue")
+	}
+}
+
+func TestSyncGitLabIssuesLabelGateCreatesJobForLabeled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitLab: "test-token"},
+		Daemon: config.DaemonConfig{MaxIterations: 3},
+	}
+	project := &config.ProjectConfig{
+		Name: "gl-project",
+		GitLab: &config.ProjectGitLab{
+			BaseURL:       "https://gitlab.com",
+			ProjectID:     "99",
+			IncludeLabels: []string{"autopr"},
+		},
+	}
+	syncer := NewSyncer(cfg, store, make(chan string, 8))
+
+	issues := []gitlabIssue{
+		{
+			IID:         2,
+			Title:       "labeled issue",
+			Description: "body",
+			WebURL:      "https://gitlab.com/group/repo/-/issues/2",
+			Labels:      []string{"AutoPR", "bug"},
+			UpdatedAt:   "2026-02-17T10:00:00Z",
+		},
+	}
+
+	syncer.syncGitLabPage(ctx, project, issues)
+
+	issue := getIssueBySourceID(t, ctx, store, "gl-project", "gitlab", "2")
+	if !issue.Eligible {
+		t.Fatalf("expected issue to be eligible")
+	}
+
+	if countJobs(t, ctx, store) != 1 {
+		t.Fatalf("expected one job for labeled gitlab issue")
+	}
+}
+
+func TestSyncGitLabIssuesNoLabelConfigAllowsAll(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitLab: "test-token"},
+		Daemon: config.DaemonConfig{MaxIterations: 3},
+	}
+	project := &config.ProjectConfig{
+		Name: "gl-project",
+		GitLab: &config.ProjectGitLab{
+			BaseURL:   "https://gitlab.com",
+			ProjectID: "99",
+			// No IncludeLabels — all issues are eligible.
+		},
+	}
+	syncer := NewSyncer(cfg, store, make(chan string, 8))
+
+	issues := []gitlabIssue{
+		{
+			IID:         3,
+			Title:       "any issue",
+			Description: "body",
+			WebURL:      "https://gitlab.com/group/repo/-/issues/3",
+			Labels:      []string{"bug"},
+			UpdatedAt:   "2026-02-17T10:00:00Z",
+		},
+	}
+
+	syncer.syncGitLabPage(ctx, project, issues)
+
+	issue := getIssueBySourceID(t, ctx, store, "gl-project", "gitlab", "3")
+	if !issue.Eligible {
+		t.Fatalf("expected issue to be eligible when no include_labels configured")
+	}
+
+	if countJobs(t, ctx, store) != 1 {
+		t.Fatalf("expected one job when no label gate configured")
+	}
+}


### PR DESCRIPTION
## Summary
- GitLab issue sync and webhook were creating jobs for every open issue regardless of labels
- Added `include_labels` config field to `[projects.gitlab]` (matching GitHub's existing behavior)
- Renamed `evaluateGitHubIssueEligibility` → `evaluateIssueEligibility` (source-agnostic)
- Added label gate check in webhook handler for open/reopen events

## Test plan
- [x] 3 new GitLab sync tests (unlabeled skipped, labeled creates job, no config allows all)
- [x] 2 new webhook label gate tests
- [x] All existing tests pass