### PR TITLE
feat: safe defaults — gate all sources by autopr label/team

### DIFF
--- a/autopr.toml.example
+++ b/autopr.toml.example
@@ -36,6 +36,23 @@ provider = "claude"  # claude or codex
 # triggers = ["awaiting_approval", "failed", "pr_created", "pr_merged"]
 # Set triggers = [] to disable all notifications.
 
+# ─── Issue Gating Defaults ───────────────────────────────────────────────────
+#
+# By default, AutoPR only processes issues that are explicitly opted-in:
+#
+#   GitHub / GitLab:  include_labels defaults to ["autopr"]
+#                     → only issues with the "autopr" label are processed
+#                     → set include_labels = [] to process ALL issues (opt-out)
+#
+#   Sentry:           assigned_team defaults to "autopr"
+#                     → only issues assigned to the #autopr team are processed
+#                     → set assigned_team = "" to process ALL issues (opt-out)
+#
+# These defaults prevent accidentally flooding the job queue with every open
+# issue on first start. Label an issue "autopr" (or assign to #autopr in
+# Sentry) when you want AutoPR to work on it.
+# ──────────────────────────────────────────────────────────────────────────────
+
 # Project definitions — add one [[projects]] block per project.
 [[projects]]
 name = "my-project"
@@ -46,17 +63,22 @@ base_branch = "main"
   [projects.gitlab]
   base_url = "https://gitlab.com"
   project_id = "12345"
-  # include_labels = ["autopr"]  # optional: ANY match; empty means all open issues
+  # include_labels = ["autopr"]  # DEFAULT — only issues labeled "autopr" are processed
+  # include_labels = ["bug"]     # custom: only process issues labeled "bug"
+  # include_labels = []           # opt-out: process ALL open issues (no label gating)
 
   # [projects.github]
   # owner = "myorg"
   # repo = "my-project"
-  # include_labels = ["autopr"]  # optional: ANY match; empty means all open issues
+  # include_labels = ["autopr"]  # DEFAULT — only issues labeled "autopr" are processed
+  # include_labels = []           # opt-out: process ALL open issues (no label gating)
 
   # [projects.sentry]
   # org = "myorg"
   # project = "my-project"
-  # assigned_team = "autopr"  # optional: only process issues assigned to #autopr team
+  # assigned_team = "autopr"     # DEFAULT — only issues assigned to #autopr team
+  # assigned_team = "my-team"    # custom: only issues assigned to #my-team
+  # assigned_team = ""            # opt-out: process ALL unresolved issues (no team gating)
 
   # Override default LLM prompts with custom markdown files:
   # [projects.prompts]

--- a/cmd/autopr/cli/init.go
+++ b/cmd/autopr/cli/init.go
@@ -236,6 +236,11 @@ provider = "codex"              # codex|claude
 # triggers = ["awaiting_approval", "failed", "pr_created", "pr_merged"]
 # Set triggers = [] to disable all notifications.
 
+# Issue gating: by default, only issues labeled "autopr" (GitHub/GitLab) or
+# assigned to the #autopr team (Sentry) are processed. This prevents
+# accidentally flooding the queue. Set include_labels = [] or assigned_team = ""
+# to opt out and process all issues.
+
 # --- GitHub example ---
 [[projects]]
 name = "my-project"
@@ -246,11 +251,16 @@ base_branch = "main"
   [projects.github]
   owner = "org"
   repo = "repo"
-  # include_labels = ["autopr"]  # optional: ANY match; empty means all open issues
+  # include_labels defaults to ["autopr"] — label issues "autopr" to process them
+  # include_labels = ["bug"]    # custom: only process issues labeled "bug"
+  # include_labels = []          # opt-out: process ALL open issues
 
   # [projects.sentry]
   # org = "my-org"
   # project = "my-project"
+  # assigned_team defaults to "autopr" — assign issues to #autopr team to process them
+  # assigned_team = "my-team"   # custom: only issues assigned to #my-team
+  # assigned_team = ""           # opt-out: process ALL unresolved issues
 
   # Override default LLM prompts with custom markdown files:
   # [projects.prompts]
@@ -268,4 +278,5 @@ base_branch = "main"
 #   [projects.gitlab]
 #   base_url = "https://gitlab.com"   # change for self-hosted GitLab
 #   project_id = "12345"
+#   # include_labels defaults to ["autopr"] — label issues "autopr" to process them
 `

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,10 +160,20 @@ type ProjectGitHub struct {
 }
 
 type ProjectSentry struct {
-	Org          string `toml:"org"`
-	Project      string `toml:"project"`
-	AssignedTeam string `toml:"assigned_team"`
+	Org          string  `toml:"org"`
+	Project      string  `toml:"project"`
+	AssignedTeam *string `toml:"assigned_team"`
 }
+
+// DefaultIncludeLabel is the default label gate applied to GitHub and GitLab
+// issue sources when include_labels is not configured. Set include_labels = []
+// in config to explicitly disable label gating.
+const DefaultIncludeLabel = "autopr"
+
+// DefaultAssignedTeam is the default Sentry team gate applied when
+// assigned_team is not configured. Set assigned_team = "" in config to
+// explicitly disable team gating.
+const DefaultAssignedTeam = "autopr"
 
 type ProjectPrompts struct {
 	Plan       string `toml:"plan"`
@@ -260,6 +270,17 @@ func applyDefaults(cfg *Config) {
 	for i := range cfg.Projects {
 		if cfg.Projects[i].BaseBranch == "" {
 			cfg.Projects[i].BaseBranch = "main"
+		}
+		// Safe defaults: require "autopr" label/team unless explicitly overridden.
+		if cfg.Projects[i].GitHub != nil && cfg.Projects[i].GitHub.IncludeLabels == nil {
+			cfg.Projects[i].GitHub.IncludeLabels = []string{DefaultIncludeLabel}
+		}
+		if cfg.Projects[i].GitLab != nil && cfg.Projects[i].GitLab.IncludeLabels == nil {
+			cfg.Projects[i].GitLab.IncludeLabels = []string{DefaultIncludeLabel}
+		}
+		if cfg.Projects[i].Sentry != nil && cfg.Projects[i].Sentry.AssignedTeam == nil {
+			defaultTeam := DefaultAssignedTeam
+			cfg.Projects[i].Sentry.AssignedTeam = &defaultTeam
 		}
 	}
 }

--- a/internal/issuesync/sentry.go
+++ b/internal/issuesync/sentry.go
@@ -25,7 +25,11 @@ func (s *Syncer) syncSentry(ctx context.Context, p *config.ProjectConfig) error 
 	project := p.Sentry.Project
 	baseURL := s.cfg.Sentry.BaseURL
 
-	query := sentryIssueQuery(p.Sentry.AssignedTeam)
+	var assignedTeam string
+	if p.Sentry.AssignedTeam != nil {
+		assignedTeam = *p.Sentry.AssignedTeam
+	}
+	query := sentryIssueQuery(assignedTeam)
 	baseAPIURL := fmt.Sprintf("%s/api/0/projects/%s/%s/issues/?query=%s&sort=date", baseURL, org, project, url.QueryEscape(query))
 
 	// Get cursor for pagination.


### PR DESCRIPTION
## Summary
- Default `include_labels` to `["autopr"]` for GitHub and GitLab sources
- Default `assigned_team` to `"autopr"` for Sentry sources
- Change `ProjectSentry.AssignedTeam` from `string` to `*string` to distinguish "not set" from "explicitly empty"
- Update `autopr.toml.example`, `ap init` template, and README with clear docs on defaults and opt-out

## Why
On first start, AutoPR was processing **every** open issue from connected sources — flooding the job queue with dozens of unwanted jobs. The safe behavior (label gating) required explicit configuration, while the dangerous behavior (process everything) was the default. This inverts that: safe by default, opt-out if you want.

## Opt-out
- `include_labels = []` — process all GitHub/GitLab issues (no label gating)
- `assigned_team = ""` — process all Sentry issues (no team gating)

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all pass
- [x] `go vet ./...` clean
- [x] New config tests: default labels for GitHub, GitLab, Sentry
- [x] New config tests: explicit empty disables gate for both labels and team
- [x] Existing tests still pass (sync, webhook, eligibility)