### PR TITLE
refactor: rename awaiting_approval to needs_pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ provider = "codex"         # codex or claude
 # webhook_url = "https://example.com/hook"               # generic JSON webhook
 # slack_webhook = "https://hooks.slack.com/services/..." # Slack incoming webhook
 # desktop = true                                          # macOS desktop notifications
-# triggers = ["awaiting_approval", "failed", "pr_created", "pr_merged"]
+# triggers = ["needs_pr", "failed", "pr_created", "pr_merged"]
 # triggers = [] disables all notifications
 
 [[projects]]
@@ -209,7 +209,7 @@ log_file = "/custom/path/autopr.log"
 
 AutoPR emits notifications from a durable DB outbox when jobs hit key states:
 
-- `awaiting_approval` (job reached `ready`)
+- `needs_pr` (job reached `ready`)
 - `failed`
 - `pr_created`
 - `pr_merged`

--- a/autopr.toml.example
+++ b/autopr.toml.example
@@ -33,7 +33,7 @@ provider = "claude"  # claude or codex
 # webhook_url = "https://example.com/hook"                     # generic JSON webhook
 # slack_webhook = "https://hooks.slack.com/services/..."       # Slack incoming webhook
 # desktop = true                                                # macOS desktop notifications
-# triggers = ["awaiting_approval", "failed", "pr_created", "pr_merged"]
+# triggers = ["needs_pr", "failed", "pr_created", "pr_merged"]
 # Set triggers = [] to disable all notifications.
 
 # ─── Issue Gating Defaults ───────────────────────────────────────────────────

--- a/cmd/autopr/cli/init.go
+++ b/cmd/autopr/cli/init.go
@@ -233,7 +233,7 @@ provider = "codex"              # codex|claude
 # webhook_url = "https://example.com/hook"                     # generic JSON webhook
 # slack_webhook = "https://hooks.slack.com/services/..."       # Slack incoming webhook
 # desktop = true                                                # macOS desktop notifications
-# triggers = ["awaiting_approval", "failed", "pr_created", "pr_merged"]
+# triggers = ["needs_pr", "failed", "pr_created", "pr_merged"]
 # Set triggers = [] to disable all notifications.
 
 # Issue gating: by default, only issues labeled "autopr" (GitHub/GitLab) or

--- a/cmd/autopr/cli/status.go
+++ b/cmd/autopr/cli/status.go
@@ -88,7 +88,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		`SELECT COUNT(*) FROM jobs WHERE state = 'approved' AND pr_merged_at IS NOT NULL AND pr_merged_at != ''`).Scan(&merged)
 	prCreated := counts["approved"] - merged
 
-	fmt.Printf("Jobs: queued=%d planning=%d implementing=%d reviewing=%d testing=%d awaiting_approval=%d failed=%d cancelled=%d pr_created=%d merged=%d rejected=%d\n",
+	fmt.Printf("Jobs: queued=%d planning=%d implementing=%d reviewing=%d testing=%d needs_pr=%d failed=%d cancelled=%d pr_created=%d merged=%d rejected=%d\n",
 		counts["queued"], counts["planning"], counts["implementing"], counts["reviewing"],
 		counts["testing"], counts["ready"], counts["failed"], counts["cancelled"], prCreated, merged, counts["rejected"])
 	return nil

--- a/docs/job_state.html
+++ b/docs/job_state.html
@@ -385,7 +385,7 @@ flowchart TD
       implementing: 'LLM writes code changes based on the plan (or review feedback).',
       reviewing:    'LLM reviews its own code. May request changes or approve.',
       testing:      'Runs the project test command. Passes → ready, fails → back to implement.',
-      ready:        'All checks passed. Waiting for human approval (or auto_pr).',
+      ready:        'All checks passed. Needs PR creation (manual or auto_pr).',
       approved:     'PR created. Terminal state.',
       rejected:     'Human rejected the job. Retryable via ap retry.',
       failed:       'A pipeline step errored. Retryable via ap retry.',

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,14 +123,14 @@ type NotificationsConfig struct {
 }
 
 const (
-	TriggerAwaitingApproval = "awaiting_approval"
-	TriggerFailed           = "failed"
-	TriggerPRCreated        = "pr_created"
-	TriggerPRMerged         = "pr_merged"
+	TriggerNeedsPR  = "needs_pr"
+	TriggerFailed   = "failed"
+	TriggerPRCreated = "pr_created"
+	TriggerPRMerged  = "pr_merged"
 )
 
 var defaultNotificationTriggers = []string{
-	TriggerAwaitingApproval,
+	TriggerNeedsPR,
 	TriggerFailed,
 	TriggerPRCreated,
 	TriggerPRMerged,
@@ -445,7 +445,7 @@ func normalizeTriggers(triggers []string) ([]string, error) {
 
 func isValidTrigger(trigger string) bool {
 	switch trigger {
-	case TriggerAwaitingApproval, TriggerFailed, TriggerPRCreated, TriggerPRMerged:
+	case TriggerNeedsPR, TriggerFailed, TriggerPRCreated, TriggerPRMerged:
 		return true
 	default:
 		return false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -380,7 +380,7 @@ test_cmd = "make test"
 	}
 
 	want := []string{
-		TriggerAwaitingApproval,
+		TriggerNeedsPR,
 		TriggerFailed,
 		TriggerPRCreated,
 		TriggerPRMerged,
@@ -428,7 +428,7 @@ func TestLoadFailsForInvalidNotificationTrigger(t *testing.T) {
 
 	content := `
 [notifications]
-triggers = ["awaiting_approval", "oops"]
+triggers = ["needs_pr", "oops"]
 
 [[projects]]
 name = "test"

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -66,7 +66,7 @@ func DisplayState(state, prMergedAt, prClosedAt string) string {
 	}
 	switch state {
 	case "ready":
-		return "awaiting approval"
+		return "needs pr"
 	case "approved":
 		return "pr created"
 	default:
@@ -195,7 +195,7 @@ func (s *Store) TransitionState(ctx context.Context, jobID, from, to string) err
 	var eventType string
 	switch to {
 	case "ready":
-		eventType = NotificationEventAwaitingApproval
+		eventType = NotificationEventNeedsPR
 	case "failed":
 		eventType = NotificationEventFailed
 	case "approved":

--- a/internal/db/notifications.go
+++ b/internal/db/notifications.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	NotificationEventAwaitingApproval = "awaiting_approval"
-	NotificationEventFailed           = "failed"
-	NotificationEventPRCreated        = "pr_created"
-	NotificationEventPRMerged         = "pr_merged"
+	NotificationEventNeedsPR  = "needs_pr"
+	NotificationEventFailed   = "failed"
+	NotificationEventPRCreated = "pr_created"
+	NotificationEventPRMerged  = "pr_merged"
 )
 
 const (
@@ -254,7 +254,7 @@ WHERE status IN ('sent', 'skipped')
 
 func validateNotificationEventType(eventType string) error {
 	switch eventType {
-	case NotificationEventAwaitingApproval, NotificationEventFailed, NotificationEventPRCreated, NotificationEventPRMerged:
+	case NotificationEventNeedsPR, NotificationEventFailed, NotificationEventPRCreated, NotificationEventPRMerged:
 		return nil
 	default:
 		return fmt.Errorf("unsupported notification event type %q", eventType)

--- a/internal/db/notifications_test.go
+++ b/internal/db/notifications_test.go
@@ -92,8 +92,8 @@ func TestNotificationEventsEnqueuedOnStateChanges(t *testing.T) {
 	for _, event := range events {
 		counts[event.EventType]++
 	}
-	if counts[NotificationEventAwaitingApproval] != 1 {
-		t.Fatalf("expected 1 awaiting_approval event, got %d", counts[NotificationEventAwaitingApproval])
+	if counts[NotificationEventNeedsPR] != 1 {
+		t.Fatalf("expected 1 needs_pr event, got %d", counts[NotificationEventNeedsPR])
 	}
 	if counts[NotificationEventPRCreated] != 1 {
 		t.Fatalf("expected 1 pr_created event, got %d", counts[NotificationEventPRCreated])

--- a/internal/notify/dispatcher_test.go
+++ b/internal/notify/dispatcher_test.go
@@ -29,12 +29,12 @@ func TestDispatcherMarksEventSent(t *testing.T) {
 	defer store.Close()
 
 	jobID := createNotifyTestJob(t, ctx, store, "1000", "Fix notifications")
-	if _, err := store.EnqueueNotificationEvent(ctx, jobID, TriggerAwaitingApproval); err != nil {
+	if _, err := store.EnqueueNotificationEvent(ctx, jobID, TriggerNeedsPR); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 
 	sender := &stubSender{name: "stub"}
-	dispatcher := NewDispatcher(store, []Sender{sender}, []string{TriggerAwaitingApproval})
+	dispatcher := NewDispatcher(store, []Sender{sender}, []string{TriggerNeedsPR})
 	processed, err := dispatcher.runOnce(ctx)
 	if err != nil {
 		t.Fatalf("run once: %v", err)
@@ -69,7 +69,7 @@ func TestDispatcherMarksDisabledTriggerSkipped(t *testing.T) {
 		t.Fatalf("enqueue: %v", err)
 	}
 
-	dispatcher := NewDispatcher(store, []Sender{&stubSender{name: "stub"}}, []string{TriggerAwaitingApproval})
+	dispatcher := NewDispatcher(store, []Sender{&stubSender{name: "stub"}}, []string{TriggerNeedsPR})
 	processed, err := dispatcher.runOnce(ctx)
 	if err != nil {
 		t.Fatalf("run once: %v", err)

--- a/internal/notify/types.go
+++ b/internal/notify/types.go
@@ -8,14 +8,14 @@ import (
 )
 
 const (
-	TriggerAwaitingApproval = "awaiting_approval"
-	TriggerFailed           = "failed"
-	TriggerPRCreated        = "pr_created"
-	TriggerPRMerged         = "pr_merged"
+	TriggerNeedsPR  = "needs_pr"
+	TriggerFailed   = "failed"
+	TriggerPRCreated = "pr_created"
+	TriggerPRMerged  = "pr_merged"
 )
 
 var AllTriggers = []string{
-	TriggerAwaitingApproval,
+	TriggerNeedsPR,
 	TriggerFailed,
 	TriggerPRCreated,
 	TriggerPRMerged,
@@ -44,7 +44,7 @@ type ChannelResult struct {
 
 func IsValidTrigger(trigger string) bool {
 	switch trigger {
-	case TriggerAwaitingApproval, TriggerFailed, TriggerPRCreated, TriggerPRMerged:
+	case TriggerNeedsPR, TriggerFailed, TriggerPRCreated, TriggerPRMerged:
 		return true
 	default:
 		return false
@@ -73,8 +73,8 @@ func TriggerSet(triggers []string) map[string]struct{} {
 
 func EventState(event string) string {
 	switch event {
-	case TriggerAwaitingApproval:
-		return "awaiting approval"
+	case TriggerNeedsPR:
+		return "needs pr"
 	case TriggerPRCreated:
 		return "pr created"
 	case TriggerPRMerged:
@@ -86,8 +86,8 @@ func EventState(event string) string {
 
 func EventLabel(event string) string {
 	switch event {
-	case TriggerAwaitingApproval:
-		return "Awaiting Approval"
+	case TriggerNeedsPR:
+		return "Needs PR"
 	case TriggerPRCreated:
 		return "PR Created"
 	case TriggerPRMerged:
@@ -100,9 +100,9 @@ func EventLabel(event string) string {
 func TestPayload() Payload {
 	now := time.Now().UTC().Format(time.RFC3339)
 	return Payload{
-		Event:      TriggerAwaitingApproval,
+		Event:      TriggerNeedsPR,
 		JobID:      "ap-job-test",
-		State:      EventState(TriggerAwaitingApproval),
+		State:      EventState(TriggerNeedsPR),
 		IssueTitle: "Test notification from AutoPR",
 		PRURL:      "https://example.com/pr/123",
 		Project:    "autopr",


### PR DESCRIPTION
## Summary
- Renames the `awaiting_approval` trigger/event/display state to `needs_pr` across the entire codebase (constants, DB schema, config, CLI output, docs, tests)
- The old name implied a PR exists and needs approval; the new name clarifies that the job is ready and **a PR needs to be created**
- Adds a SQLite migration that recreates `notification_events` with the updated CHECK constraint and converts existing `awaiting_approval` rows to `needs_pr`

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `go vet ./...` no issues
- [x] `grep -ri "awaiting.approval"` returns only migration code (which must reference the old name)
- [ ] Verify `docs/job_state.html` tooltip for "ready" state shows updated description