### PR TITLE
fix(tui): split hint bar into two lines and isolate filter mode

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1325,16 +1325,23 @@ func (m Model) listView() string {
 		pageLabel = 0
 		pageNum = 0
 	}
-	hints := []string{fmt.Sprintf("Page %d/%d (%d jobs)", pageNum, pageLabel, len(m.jobs)), "j/k navigate", "enter details", "f filter"}
-	if m.cursor < len(m.jobs) && db.IsCancellableState(m.jobs[m.cursor].State) {
-		hints = append(hints, "c cancel")
-	}
-	hints = append(hints, "F clear filters", "s sort", "S toggle sort dir")
 	if m.filterMode {
-		hints = append(hints, "s state", "p project", "esc cancel filter")
+		// Filter mode: show only filter controls (navigation is disabled).
+		filterHints := []string{"FILTER:", "s state", "p project", "F clear all", "esc done", "q quit"}
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render(strings.Join(filterHints, "  ")))
+	} else {
+		// Normal mode: primary nav line + secondary actions line.
+		line1 := []string{fmt.Sprintf("Page %d/%d (%d jobs)", pageNum, pageLabel, len(m.jobs)), "j/k navigate", "enter details"}
+		if m.cursor < len(m.jobs) && db.IsCancellableState(m.jobs[m.cursor].State) {
+			line1 = append(line1, "c cancel")
+		}
+		line1 = append(line1, "r refresh", "q quit")
+		b.WriteString(dimStyle.Render(strings.Join(line1, "  ")))
+		b.WriteString("\n")
+
+		line2 := []string{"f filter", "F clear filters", "s sort", "S sort dir"}
+		b.WriteString(dimStyle.Render(strings.Join(line2, "  ")))
 	}
-	hints = append(hints, "r refresh", "q quit")
-	b.WriteString(dimStyle.Render(strings.Join(hints, "  ")))
 	return b.String()
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -71,7 +71,7 @@ func TestListViewShowsFilterIndicatorAndFooterHints(t *testing.T) {
 
 	m.filterMode = true
 	filterModeView := m.listView()
-	for _, want := range []string{"s state", "p project", "F clear filters", "esc cancel filter"} {
+	for _, want := range []string{"s state", "p project", "F clear all", "esc done"} {
 		if !strings.Contains(filterModeView, want) {
 			t.Fatalf("expected filter-mode hint %q, got:\n%s", want, filterModeView)
 		}
@@ -292,7 +292,7 @@ func TestListViewSortFooterHints(t *testing.T) {
 	if !strings.Contains(view, "s sort") {
 		t.Fatalf("expected footer hint for sort key, got:\n%s", view)
 	}
-	if !strings.Contains(view, "S toggle sort dir") {
+	if !strings.Contains(view, "S sort dir") {
 		t.Fatalf("expected footer hint for sort direction key, got:\n%s", view)
 	}
 }


### PR DESCRIPTION
## Summary
- Split the footer hint bar into two lines: navigation/page info on line 1, action shortcuts (filter, sort) on line 2
- In filter mode, replace both lines with a single highlighted line showing only keys that work in that mode
- Remove duplicate `s` key hint (was showing both "s sort" and "s state" simultaneously)
- Shorten labels (`S sort dir`, `F clear all`, `esc done`)

## Test plan
- [x] All existing tests pass with updated assertions
- [ ] Verify normal mode shows two-line footer in TUI
- [ ] Verify filter mode shows single amber FILTER: line
- [ ] Confirm `r refresh` and `q quit` are visible in both modes