### PR TITLE
[AutoPR] refactor(config): rename DefaultIncludeLabel to DefaultLabel

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,10 +165,10 @@ type ProjectSentry struct {
 	AssignedTeam *string `toml:"assigned_team"`
 }
 
-// DefaultIncludeLabel is the default label gate applied to GitHub and GitLab
+// DefaultLabel is the default label gate applied to GitHub and GitLab
 // issue sources when include_labels is not configured. Set include_labels = []
 // in config to explicitly disable label gating.
-const DefaultIncludeLabel = "autopr"
+const DefaultLabel = "autopr"
 
 // DefaultAssignedTeam is the default Sentry team gate applied when
 // assigned_team is not configured. Set assigned_team = "" in config to
@@ -273,10 +273,10 @@ func applyDefaults(cfg *Config) {
 		}
 		// Safe defaults: require "autopr" label/team unless explicitly overridden.
 		if cfg.Projects[i].GitHub != nil && cfg.Projects[i].GitHub.IncludeLabels == nil {
-			cfg.Projects[i].GitHub.IncludeLabels = []string{DefaultIncludeLabel}
+			cfg.Projects[i].GitHub.IncludeLabels = []string{DefaultLabel}
 		}
 		if cfg.Projects[i].GitLab != nil && cfg.Projects[i].GitLab.IncludeLabels == nil {
-			cfg.Projects[i].GitLab.IncludeLabels = []string{DefaultIncludeLabel}
+			cfg.Projects[i].GitLab.IncludeLabels = []string{DefaultLabel}
 		}
 		if cfg.Projects[i].Sentry != nil && cfg.Projects[i].Sentry.AssignedTeam == nil {
 			defaultTeam := DefaultAssignedTeam

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -480,7 +480,7 @@ test_cmd = "make test"
 	if !ok || p.GitHub == nil {
 		t.Fatalf("expected github project")
 	}
-	want := []string{DefaultIncludeLabel}
+	want := []string{DefaultLabel}
 	if !reflect.DeepEqual(p.GitHub.IncludeLabels, want) {
 		t.Fatalf("expected default include_labels %v, got %v", want, p.GitHub.IncludeLabels)
 	}
@@ -514,7 +514,7 @@ test_cmd = "make test"
 	if !ok || p.GitLab == nil {
 		t.Fatalf("expected gitlab project")
 	}
-	want := []string{DefaultIncludeLabel}
+	want := []string{DefaultLabel}
 	if !reflect.DeepEqual(p.GitLab.IncludeLabels, want) {
 		t.Fatalf("expected default include_labels %v, got %v", want, p.GitLab.IncludeLabels)
 	}


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/105

**Issue:** refactor(config): rename DefaultIncludeLabel to DefaultLabel

<details>
<summary>Plan</summary>

`DefaultIncludeLabel` rename plan

1) Files to modify
- `internal/config/config.go`
- `internal/config/config_test.go`
- No new files

2) Specific changes per file

- `internal/config/config.go`
  1. Rename constant declaration:
     - `const DefaultIncludeLabel = "autopr"` → `const DefaultLabel = "autopr"`
  2. Update declaration comment to match:
     - `DefaultIncludeLabel is ...` → `DefaultLabel is ...`
  3. Update all internal references:
     - `cfg.Projects[i].GitHub.IncludeLabels = []string{DefaultIncludeLabel}` → `...{DefaultLabel}`
     - `cfg.Projects[i].GitLab.IncludeLabels = []string{DefaultIncludeLabel}` → `...{DefaultLabel}`

- `internal/config/config_test.go`
  1. Update test expectations:
     - `want := []string{DefaultIncludeLabel}` → `want := []string{DefaultLabel}` (all occurrences)
  2. Verify any future test names/messages mentioning old constant name if present (none currently from scan), rename only if they exist.

3) Potential risks / edge cases
- Public API impact: if any external package imports this internal package and uses the constant, compile breaks (though impact is limited by `internal/` package boundaries).
- Incomplete rename would leave mixed identifiers and cause compile failures or inconsistent naming.
- Ensure only the identifier is changed; keep value `"autopr"` unchanged to avoid behavioral change.
- Keep constant casing/style consistent with existing naming conventions in the package.

4) Testing strategy
- Run `rg`/search verification to ensure zero `DefaultIncludeLabel` references remain.
- Run targeted tests first:
  - `go test ./internal/config`
- Run full compile/test to catch cross-package fallout:
  - `go test ./...`
- If CI includes lint/static checks, run the standard project pipeline command afterward.
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `84b077bd`_
