### PR TITLE
[AutoPR] feat(config): add Version constant to config package

### DIFF
--- a/cmd/autopr/cli/root.go
+++ b/cmd/autopr/cli/root.go
@@ -18,7 +18,7 @@ var (
 	cfgPath string
 	verbose bool
 	jsonOut bool
-	version = "dev"
+	version = config.Version
 	commit  = "unknown"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+const Version = "0.1.0"
+
 // Credentials holds tokens loaded from credentials.toml.
 type Credentials struct {
 	GitHubToken   string `toml:"github_token"`


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/104

**Issue:** feat(config): add Version constant to config package

<details>
<summary>Plan</summary>

Implementation plan:

1. Scope and files
- `internal/config/config.go` (modify)
- `cmd/autopr/cli/root.go` (modify)
- No new files
- No other production files per “isolated change” requirement

2. Specific changes

1. `internal/config/config.go`
- Add an exported package constant at the top-level, near the existing const blocks:
  - `const Version = "0.1.0"`
- Keep it in the config package namespace so CLI can import/use it.

2. `cmd/autopr/cli/root.go`
- Change the `version` variable initialization from hardcoded `"dev"` to reference the config constant:
  - `version = config.Version`
- Keep `commit = "unknown"` and `Version: fmt.Sprintf("%s (%s)", version, commit)` as-is so `--version` output remains:
  - release/local dev default: `0.1.0 (unknown)` unless `commit` is injected.

3. Rollout/behavior verification
- Build with default local values:
  - `--version` should report `0.1.0 (unknown)` (plus `commit` when injected).
- Release flow with goreleaser ldflags should still inject `cmd/autopr/cli.version` and override default when built from tags.

3. Potential risks / edge cases
- Version format mismatch: constant is `0.1.0` while upstream release tags are often `v0.1.0`; existing update compare logic likely handles this, but verify expected display/UX.
- Existing behavior changes from `"dev"` to `"0.1.0"` in any user-facing path that reads `version` (not just `--version`), including update checks and startup notices.
- Test expectations that assert old `version` defaults (`"dev"`) would break; only if such assertions exist in current or future tests.
- Since `version` remains linkable via ldflags, build reproducibility relies on that injection mechanism still targeting `autopr/cmd/autopr/cli.version`.

4. Testing strategy
- Unit/integration scope (no code changes needed, just plan):
  - `go test ./internal/config ./cmd/autopr/cli`
- Targeted assertions to add/check if test coverage exists:
  - Confirm `version` default is `config.Version` in a CLI-start path

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `a217e968`_
