### PR TITLE
[AutoPR] feat(cli): add --json output flag to ap status command

### DIFF
--- a/cmd/autopr/cli/status.go
+++ b/cmd/autopr/cli/status.go
@@ -10,6 +10,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type statusJobCounts struct {
+	Queued       int `json:"queued"`
+	Planning     int `json:"planning"`
+	Implementing int `json:"implementing"`
+	Reviewing    int `json:"reviewing"`
+	Testing      int `json:"testing"`
+	NeedsPR      int `json:"needs_pr"`
+	Failed       int `json:"failed"`
+	Cancelled    int `json:"cancelled"`
+	Rejected     int `json:"rejected"`
+	PRCreated    int `json:"pr_created"`
+	Merged       int `json:"merged"`
+}
+
+type statusOutput struct {
+	Running   bool            `json:"running"`
+	PID       string          `json:"pid"`
+	JobCounts statusJobCounts `json:"job_counts"`
+}
+
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show daemon status and queue depth",
@@ -87,25 +107,25 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if prCreated < 0 {
 		prCreated = 0
 	}
-	jobCounts := map[string]int{
-		"queued":       counts["queued"],
-		"planning":     counts["planning"],
-		"implementing": counts["implementing"],
-		"reviewing":    counts["reviewing"],
-		"testing":      counts["testing"],
-		"needs_pr":     counts["ready"],
-		"failed":       counts["failed"],
-		"cancelled":    counts["cancelled"],
-		"rejected":     counts["rejected"],
-		"pr_created":   prCreated,
-		"merged":       merged,
+	jobCounts := statusJobCounts{
+		Queued:       counts["queued"],
+		Planning:     counts["planning"],
+		Implementing: counts["implementing"],
+		Reviewing:    counts["reviewing"],
+		Testing:      counts["testing"],
+		NeedsPR:      counts["ready"],
+		Failed:       counts["failed"],
+		Cancelled:    counts["cancelled"],
+		Rejected:     counts["rejected"],
+		PRCreated:    prCreated,
+		Merged:       merged,
 	}
 
 	if jsonOut {
-		printJSON(map[string]any{
-			"running":    running,
-			"pid":        pidStr,
-			"job_counts": jobCounts,
+		printJSON(statusOutput{
+			Running:   running,
+			PID:       pidStr,
+			JobCounts: jobCounts,
 		})
 		return nil
 	}

--- a/cmd/autopr/cli/status_test.go
+++ b/cmd/autopr/cli/status_test.go
@@ -195,6 +195,15 @@ func writeStatusConfigWithPID(t *testing.T, dir, pidPath string) string {
 
 [daemon]
 pid_file = %q
+
+[[projects]]
+name = "project"
+repo_url = "https://github.com/autopr/placeholder"
+test_cmd = "echo ok"
+
+[projects.github]
+owner = "autopr"
+repo = "placeholder"
 `, dbPath, pidPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/103

**Issue:** feat(cli): add --json output flag to ap status command

<details>
<summary>Plan</summary>

`ap status` already has `--json` plumbing at CLI level via `jsonOut` in `cmd/autopr/cli/root.go`, so this issue can be implemented in one file (`cmd/autopr/cli/status.go`) by making JSON output match the table semantics.

## 1) Files to modify/create

1. `cmd/autopr/cli/status.go` (required)
2. `cmd/autopr/cli/status_test.go` (optional, recommended for safety if allowed; issue says only status command behavior changes)

## 2) Specific changes in `cmd/autopr/cli/status.go`

1. Keep `statusCmd` wiring unchanged; keep behavior gated by `jsonOut` as today (no root change).
2. In `runStatus`, introduce an explicit normalized status payload instead of the current ad-hoc map-only shape.
3. Initialize job count map with all expected statuses before scanning SQL rows so JSON always includes explicit zeroes, not omitted keys.
4. Preserve existing `merged` logic (`state='approved'` + `pr_merged_at` set) and compute `pr_created = max(0, approved - merged)`.
5. Build JSON payload with stable keys matching table intent, for example:
   - `running` (bool)
   - `pid` (string)
   - `job_counts` (object) including:
     - `queued`, `planning`, `implementing`, `reviewing`, `testing`,
     - `needs_pr` (or `ready` but keep one consistent key),
     - `failed`, `cancelled`, `rejected`,
     - `pr_created`, `merged`
6. Ensure JSON path returns early with `printJSON(payload)` and the table path remains unchanged.

## 3) Potential risks / edge cases

1. Missing-state omission: without map initialization, JSON may omit zero-count states, breaking schema consumers.
2. Count integrity: `pr_created` derivation can go negative if data is inconsistent; clamp at 0.
3. Parseability differences: keep output schema deterministic (explicit keys) to avoid clients relying on map order.
4. PID file edge cases: unreadable/non-numeric PID files currently degrade to `running=false`; keep that behavior for backward compatibility.
5. DB/daemon snapshot drift: separate count queries can reflect slightly diffe

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `9ded1850`_
