### PR TITLE
fix(tui): prevent stdout/stderr leaks and approve race condition

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -10,9 +10,11 @@ import (
 // It runs `git add -N .` first so untracked files appear in the diff output.
 func DiffAgainstBase(ctx context.Context, worktreePath, baseBranch string) (string, error) {
 	// Mark untracked files as intent-to-add so they appear in diff output.
+	// Use CombinedOutput to capture/discard any diagnostics from git add -N
+	// and prevent them from leaking to the TUI terminal.
 	addN := exec.CommandContext(ctx, "git", "add", "-N", ".")
 	addN.Dir = worktreePath
-	_ = addN.Run()
+	_, _ = addN.CombinedOutput()
 
 	out, err := runGitOutput(ctx, worktreePath, "diff", fmt.Sprintf("origin/%s", baseBranch))
 	if err != nil {
@@ -26,7 +28,7 @@ func DiffStatAgainstBase(ctx context.Context, worktreePath, baseBranch string) (
 	// Mark untracked files as intent-to-add so they appear in diff output.
 	addN := exec.CommandContext(ctx, "git", "add", "-N", ".")
 	addN.Dir = worktreePath
-	_ = addN.Run()
+	_, _ = addN.CombinedOutput()
 
 	out, err := runGitOutput(ctx, worktreePath, "diff", "--stat", fmt.Sprintf("origin/%s", baseBranch))
 	if err != nil {

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -12,7 +12,7 @@ import (
 
 // FetchBranch fetches the latest commits for the given base branch.
 func FetchBranch(ctx context.Context, dir, baseBranch string) error {
-	return runGit(ctx, dir, "fetch", "origin", "--", baseBranch)
+	return runGitCaptured(ctx, dir, "fetch", "origin", "--", baseBranch)
 }
 
 // ConfigureDiff3 enables diff3 conflict markers for clearer rebase conflict output.

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -79,6 +79,12 @@ func PushBranchWithLease(ctx context.Context, dir, branchName string) error {
 	return runGit(ctx, dir, "push", "origin", "--force-with-lease", branchName)
 }
 
+// PushBranchWithLeaseCaptured pushes a branch with --force-with-lease without
+// writing output to the process stdout/stderr (safe for TUI callers).
+func PushBranchWithLeaseCaptured(ctx context.Context, dir, branchName string) error {
+	return runGitCaptured(ctx, dir, "push", "origin", "--force-with-lease", branchName)
+}
+
 // PushBranchCaptured pushes a branch to origin without writing output to the
 // process stdout/stderr. Any git output is captured and included in errors.
 func PushBranchCaptured(ctx context.Context, dir, branchName string) error {


### PR DESCRIPTION
## Summary
- Use captured git execution for `FetchBranch`, push, and `git add -N` so child-process output cannot corrupt the Bubble Tea TUI
- Add `PushBranchWithLeaseCaptured` for TUI-safe force push
- Sink `openURL` child-process output via `io.Discard`
- Re-fetch job state before approve transition to handle pipeline auto-approval race (`ready → approved` already done by `maybeAutoPR`)

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Open TUI, approve a `needs pr` job — no git output leaks into terminal
- [ ] Approve a job that pipeline already auto-approved — no "Action failed" error
- [ ] Press `b`/`i` to open PR/issue URL — no child-process diagnostics in TUI
- [ ] View diff (`d` key) — no `git add -N` output flicker