### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // Credentials holds tokens loaded from credentials.toml.
 type Credentials struct {


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.2.0

Includes recent merges:
- #66 MIT license
- #64 TUI timestamps in local timezone
- #113 TUI pagination shortcuts
- #81 Delete remote branch after PR merge/close
- #128 Fix TUI stdout leaks and approve race condition