### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-const Version = "0.2.0"
+const Version = "0.7.0"
 
 // Credentials holds tokens loaded from credentials.toml.
 type Credentials struct {


### PR DESCRIPTION
Fix incorrect version bump — was 0.6.0, mistakenly set to 0.2.0 in #129, now corrected to 0.7.0.