### PR TITLE
feat: add CI check polling after PR creation

### DIFF
--- a/autopr.toml.example
+++ b/autopr.toml.example
@@ -22,6 +22,8 @@ max_iterations = 3
 sync_interval = "5m"
 # pid_file = "/custom/path/autopr.pid"   # default: ~/.local/state/autopr/autopr.pid
 # auto_pr = false               # Set true to auto-create PRs after tests pass
+# ci_check_interval = "30s"   # How often to poll GitHub check-runs
+# ci_check_timeout = "30m"    # Max wait for CI checks before rejecting
 
 # [sentry]
 # base_url = "https://sentry.io"  # uncomment for self-hosted Sentry

--- a/cmd/autopr/cli/init.go
+++ b/cmd/autopr/cli/init.go
@@ -213,6 +213,8 @@ const configTemplate = `# AutoPR configuration
 # State files (logs, PID) default to ~/.local/state/autopr/
 # Override with XDG_DATA_HOME / XDG_STATE_HOME or set paths explicitly below.
 
+config_version = 1
+
 log_level = "info"              # debug|info|warn|error
 
 [daemon]
@@ -222,6 +224,8 @@ max_workers = 3
 max_iterations = 3              # implement<->review loop default
 sync_interval = "5m"            # GitHub/Sentry poll interval
 auto_pr = false                 # set true to auto-create PRs after tests pass
+ci_check_interval = "30s"       # how often to poll CI check-runs
+ci_check_timeout = "30m"        # max wait for CI checks before rejecting
 
 # [sentry]
 # base_url = "https://sentry.io"  # uncomment for self-hosted Sentry

--- a/cmd/autopr/cli/reject.go
+++ b/cmd/autopr/cli/reject.go
@@ -45,12 +45,8 @@ func runReject(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("job %s is in state %q, must be 'ready' to reject", jobID, job.State)
 	}
 
-	if err := store.TransitionState(cmd.Context(), jobID, "ready", "rejected"); err != nil {
+	if err := store.RejectJob(cmd.Context(), jobID, "ready", rejectReason); err != nil {
 		return err
-	}
-
-	if rejectReason != "" {
-		_ = store.UpdateJobField(cmd.Context(), jobID, "reject_reason", rejectReason)
 	}
 
 	if jsonOut {

--- a/cmd/autopr/cli/root.go
+++ b/cmd/autopr/cli/root.go
@@ -81,6 +81,9 @@ func loadConfig() (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := config.MigrateConfigFile(path); err != nil {
+		slog.Warn("config migration skipped", "err", err)
+	}
 	return config.Load(path)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,10 +76,11 @@ func SaveCredentials(creds *Credentials) error {
 }
 
 type Config struct {
-	DBPath    string `toml:"db_path"`
-	ReposRoot string `toml:"repos_root"`
-	LogLevel  string `toml:"log_level"`
-	LogFile   string `toml:"log_file"`
+	ConfigVersion int    `toml:"config_version"`
+	DBPath        string `toml:"db_path"`
+	ReposRoot     string `toml:"repos_root"`
+	LogLevel      string `toml:"log_level"`
+	LogFile       string `toml:"log_file"`
 
 	Daemon        DaemonConfig        `toml:"daemon"`
 	Tokens        TokensConfig        `toml:"tokens"`
@@ -94,13 +95,15 @@ type Config struct {
 }
 
 type DaemonConfig struct {
-	WebhookPort   int    `toml:"webhook_port"`
-	WebhookSecret string `toml:"webhook_secret"`
-	MaxWorkers    int    `toml:"max_workers"`
-	MaxIterations int    `toml:"max_iterations"`
-	SyncInterval  string `toml:"sync_interval"`
-	PIDFile       string `toml:"pid_file"`
-	AutoPR        bool   `toml:"auto_pr"`
+	WebhookPort     int    `toml:"webhook_port"`
+	WebhookSecret   string `toml:"webhook_secret"`
+	MaxWorkers      int    `toml:"max_workers"`
+	MaxIterations   int    `toml:"max_iterations"`
+	SyncInterval    string `toml:"sync_interval"`
+	PIDFile         string `toml:"pid_file"`
+	AutoPR          bool   `toml:"auto_pr"`
+	CICheckInterval string `toml:"ci_check_interval"`
+	CICheckTimeout  string `toml:"ci_check_timeout"`
 }
 
 type TokensConfig struct {
@@ -270,6 +273,12 @@ func applyDefaults(cfg *Config) {
 			cfg.Daemon.PIDFile = "autopr.pid"
 		}
 	}
+	if cfg.Daemon.CICheckInterval == "" {
+		cfg.Daemon.CICheckInterval = "30s"
+	}
+	if cfg.Daemon.CICheckTimeout == "" {
+		cfg.Daemon.CICheckTimeout = "30m"
+	}
 	if cfg.Sentry.BaseURL == "" {
 		cfg.Sentry.BaseURL = "https://sentry.io"
 	}
@@ -369,6 +378,12 @@ func validate(cfg *Config) error {
 	}
 	if _, err := time.ParseDuration(cfg.Daemon.SyncInterval); err != nil {
 		return fmt.Errorf("invalid daemon.sync_interval %q: %w", cfg.Daemon.SyncInterval, err)
+	}
+	if _, err := time.ParseDuration(cfg.Daemon.CICheckInterval); err != nil {
+		return fmt.Errorf("invalid daemon.ci_check_interval %q: %w", cfg.Daemon.CICheckInterval, err)
+	}
+	if _, err := time.ParseDuration(cfg.Daemon.CICheckTimeout); err != nil {
+		return fmt.Errorf("invalid daemon.ci_check_timeout %q: %w", cfg.Daemon.CICheckTimeout, err)
 	}
 	normalizedTriggers, err := validateNotificationsConfig(cfg.Notifications)
 	if err != nil {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,258 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+// CurrentConfigVersion is the latest config schema version. Bump this only
+// when adding new fields or changing the config structure.
+const CurrentConfigVersion = 1
+
+// MigrationFunc transforms raw TOML bytes from one version to the next.
+type MigrationFunc func([]byte) ([]byte, error)
+
+// migrations maps from-version → transform function.
+// Each func upgrades from version N to N+1.
+var migrations = map[int]MigrationFunc{
+	0: migrateV0toV1,
+}
+
+// MigrateConfigFile reads the config at path, detects its schema version,
+// and applies any pending migrations. A timestamped backup is created before
+// any changes are written. Returns nil if the config is already current or
+// if the file does not exist.
+func MigrateConfigFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read config for migration: %w", err)
+	}
+
+	ver := detectConfigVersion(data)
+	if ver >= CurrentConfigVersion {
+		return nil
+	}
+
+	// Capture original file permissions.
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat config: %w", err)
+	}
+	mode := info.Mode().Perm()
+
+	// Create backup before modifying (preserving source permissions).
+	if err := backupConfigFile(path, data, mode); err != nil {
+		return fmt.Errorf("backup config: %w", err)
+	}
+
+	// Apply migrations sequentially.
+	current := data
+	for v := ver; v < CurrentConfigVersion; v++ {
+		fn, ok := migrations[v]
+		if !ok {
+			return fmt.Errorf("no migration registered for version %d → %d", v, v+1)
+		}
+		current, err = fn(current)
+		if err != nil {
+			return fmt.Errorf("migrate v%d→v%d: %w", v, v+1, err)
+		}
+	}
+
+	if err := os.WriteFile(path, current, mode); err != nil {
+		return fmt.Errorf("write migrated config: %w", err)
+	}
+
+	slog.Info("config migrated", "from_version", ver, "to_version", CurrentConfigVersion, "path", path)
+	return nil
+}
+
+// detectConfigVersion decodes only the config_version field from raw TOML.
+// Returns 0 if the field is absent.
+func detectConfigVersion(data []byte) int {
+	var v struct {
+		ConfigVersion int `toml:"config_version"`
+	}
+	if _, err := toml.NewDecoder(bytes.NewReader(data)).Decode(&v); err != nil {
+		return 0
+	}
+	return v.ConfigVersion
+}
+
+// backupConfigFile writes data to <path>.bak.<YYYYMMdd-HHmmss>,
+// preserving the source file's permissions.
+func backupConfigFile(path string, data []byte, mode os.FileMode) error {
+	// Keep backups at most as permissive as the source config, never exposing
+	// credentials to group/other readers.
+	backupMode := mode & 0o700
+	if backupMode == 0 {
+		backupMode = 0o600
+	}
+	ts := time.Now().Format("20060102-150405")
+	backupPath := fmt.Sprintf("%s.bak.%s", path, ts)
+	return os.WriteFile(backupPath, data, backupMode)
+}
+
+// migrateV0toV1 inserts ci_check_interval and ci_check_timeout into the
+// [daemon] section (if present) and stamps config_version = 1.
+func migrateV0toV1(data []byte) ([]byte, error) {
+	result := data
+
+	// Insert CI fields into [daemon] section if it exists.
+	result = tomlInsertInSection(result, "daemon", []keyValue{
+		{Key: "ci_check_interval", Value: `"30s"`, Comment: "# How often to poll CI check-runs"},
+		{Key: "ci_check_timeout", Value: `"30m"`, Comment: "# Max wait for CI checks before rejecting"},
+	})
+
+	// Stamp config_version = 1.
+	result = tomlSetConfigVersion(result, 1)
+
+	return result, nil
+}
+
+// keyValue represents a TOML key = value pair to insert.
+type keyValue struct {
+	Key     string
+	Value   string
+	Comment string // optional inline comment
+}
+
+// tomlSetConfigVersion sets or inserts config_version at the top level.
+func tomlSetConfigVersion(data []byte, version int) []byte {
+	versionLine := fmt.Sprintf("config_version = %d", version)
+	re := regexp.MustCompile(`(?m)^config_version\s*=\s*\d+`)
+	if re.Match(data) {
+		return re.ReplaceAll(data, []byte(versionLine))
+	}
+	return tomlInsertTopLevel(data, versionLine)
+}
+
+// tomlInsertTopLevel inserts a line after leading comments/blank lines,
+// before the first key or section header.
+func tomlInsertTopLevel(data []byte, line string) []byte {
+	lines := strings.Split(string(data), "\n")
+	insertIdx := 0
+
+	// Skip leading comments and blank lines.
+	for i, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			insertIdx = i + 1
+			continue
+		}
+		break
+	}
+
+	// Insert line with a trailing blank line for readability.
+	result := make([]string, 0, len(lines)+2)
+	result = append(result, lines[:insertIdx]...)
+	result = append(result, line)
+	// Add blank line separator if the next line is not blank.
+	if insertIdx < len(lines) && strings.TrimSpace(lines[insertIdx]) != "" {
+		result = append(result, "")
+	}
+	result = append(result, lines[insertIdx:]...)
+
+	return []byte(strings.Join(result, "\n"))
+}
+
+// tomlInsertInSection finds a [section] header and appends key-value pairs
+// after the last key in that section. Skips keys that are already present.
+func tomlInsertInSection(data []byte, section string, kvs []keyValue) []byte {
+	lines := strings.Split(string(data), "\n")
+	sectionHeader := fmt.Sprintf("[%s]", section)
+
+	inSection := false
+	insertIdx := -1
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == sectionHeader {
+			inSection = true
+			insertIdx = i + 1
+			continue
+		}
+
+		if inSection {
+			// Another section or array-of-tables header ends the current section.
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			// Track last non-empty, non-comment line as insert point.
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				insertIdx = i + 1
+			}
+			// Also advance past comments and blank lines within the section.
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				if insertIdx <= i {
+					insertIdx = i + 1
+				}
+			}
+		}
+	}
+
+	if insertIdx < 0 {
+		// Section not found — nothing to insert.
+		return data
+	}
+
+	// Build lines to insert, skipping keys already present.
+	var toInsert []string
+	for _, kv := range kvs {
+		if sectionContainsKey(lines, section, kv.Key) {
+			continue
+		}
+		entry := fmt.Sprintf("%s = %s", kv.Key, kv.Value)
+		if kv.Comment != "" {
+			entry += "   " + kv.Comment
+		}
+		toInsert = append(toInsert, entry)
+	}
+
+	if len(toInsert) == 0 {
+		return data
+	}
+
+	result := make([]string, 0, len(lines)+len(toInsert))
+	result = append(result, lines[:insertIdx]...)
+	result = append(result, toInsert...)
+	result = append(result, lines[insertIdx:]...)
+
+	return []byte(strings.Join(result, "\n"))
+}
+
+// sectionContainsKey checks if a key exists within a TOML section.
+func sectionContainsKey(lines []string, section, key string) bool {
+	sectionHeader := fmt.Sprintf("[%s]", section)
+	inSection := false
+	keyPattern := regexp.MustCompile(`^\s*` + regexp.QuoteMeta(key) + `\s*=`)
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == sectionHeader {
+			inSection = true
+			continue
+		}
+
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") {
+				return false
+			}
+			if keyPattern.MatchString(line) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,414 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigrateV0toV1_FullMigration(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `# My AutoPR config
+log_level = "info"
+
+[daemon]
+webhook_port = 9847
+max_workers = 3
+sync_interval = "5m"
+
+[llm]
+provider = "codex"
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	got := string(data)
+
+	// config_version = 1 should be present.
+	if !strings.Contains(got, "config_version = 1") {
+		t.Fatalf("expected config_version = 1 in output:\n%s", got)
+	}
+	// CI fields should be present.
+	if !strings.Contains(got, `ci_check_interval = "30s"`) {
+		t.Fatalf("expected ci_check_interval in output:\n%s", got)
+	}
+	if !strings.Contains(got, `ci_check_timeout = "30m"`) {
+		t.Fatalf("expected ci_check_timeout in output:\n%s", got)
+	}
+	// Original content preserved.
+	if !strings.Contains(got, "# My AutoPR config") {
+		t.Fatalf("expected original comment preserved:\n%s", got)
+	}
+	if !strings.Contains(got, `log_level = "info"`) {
+		t.Fatalf("expected log_level preserved:\n%s", got)
+	}
+}
+
+func TestMigratePreservesExistingValues(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `log_level = "info"
+
+[daemon]
+webhook_port = 9847
+ci_check_interval = "1m"
+ci_check_timeout = "45m"
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(data)
+
+	// Existing values must be preserved, not overwritten.
+	if !strings.Contains(got, `ci_check_interval = "1m"`) {
+		t.Fatalf("expected existing ci_check_interval preserved:\n%s", got)
+	}
+	if !strings.Contains(got, `ci_check_timeout = "45m"`) {
+		t.Fatalf("expected existing ci_check_timeout preserved:\n%s", got)
+	}
+	// Should NOT contain the default values.
+	if strings.Contains(got, `ci_check_interval = "30s"`) {
+		t.Fatalf("should not have overwritten ci_check_interval:\n%s", got)
+	}
+}
+
+func TestMigrateNoDaemonSection(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `log_level = "info"
+
+[llm]
+provider = "codex"
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(data)
+
+	// config_version should still be stamped.
+	if !strings.Contains(got, "config_version = 1") {
+		t.Fatalf("expected config_version = 1:\n%s", got)
+	}
+	// CI fields should NOT be inserted since there's no [daemon] section.
+	if strings.Contains(got, "ci_check_interval") {
+		t.Fatalf("should not insert ci_check_interval without [daemon] section:\n%s", got)
+	}
+}
+
+func TestMigrateIdempotent(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `# comment
+log_level = "info"
+
+[daemon]
+webhook_port = 9847
+sync_interval = "5m"
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// First migration.
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+
+	firstData, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+
+	// Count backup files before second migration.
+	entries1, _ := os.ReadDir(tmp)
+	bakCount1 := countBackups(entries1)
+
+	// Second migration — should be a no-op.
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+
+	secondData, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+
+	if string(firstData) != string(secondData) {
+		t.Fatalf("second migration changed file:\n--- first ---\n%s\n--- second ---\n%s", firstData, secondData)
+	}
+
+	// No new backup should be created.
+	entries2, _ := os.ReadDir(tmp)
+	bakCount2 := countBackups(entries2)
+	if bakCount2 != bakCount1 {
+		t.Fatalf("expected no new backup, got %d → %d", bakCount1, bakCount2)
+	}
+}
+
+func TestMigrateCreatesBackup(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `log_level = "info"
+
+[daemon]
+webhook_port = 9847
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+
+	bakCount := countBackups(entries)
+	if bakCount != 1 {
+		t.Fatalf("expected 1 backup file, got %d", bakCount)
+	}
+
+	// Verify backup contains original content.
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "config.toml.bak.") {
+			backupData, err := os.ReadFile(filepath.Join(tmp, e.Name()))
+			if err != nil {
+				t.Fatalf("read backup: %v", err)
+			}
+			if string(backupData) != input {
+				t.Fatalf("backup content mismatch:\nexpected:\n%s\ngot:\n%s", input, backupData)
+			}
+		}
+	}
+}
+
+func TestMigratePreservesComments(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `# Top-level comment about the file
+# Second line of comment
+
+log_level = "info"  # inline comment
+
+[daemon]
+webhook_port = 9847  # port comment
+# A comment about workers
+max_workers = 3
+
+[llm]
+provider = "codex"
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(data)
+
+	// All original comments should survive.
+	for _, want := range []string{
+		"# Top-level comment about the file",
+		"# Second line of comment",
+		"# inline comment",
+		"# port comment",
+		"# A comment about workers",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected comment %q preserved in:\n%s", want, got)
+		}
+	}
+}
+
+func TestMigrateAlreadyCurrent(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `config_version = 1
+log_level = "info"
+
+[daemon]
+webhook_port = 9847
+ci_check_interval = "30s"
+ci_check_timeout = "30m"
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// No backup should be created.
+	entries, _ := os.ReadDir(tmp)
+	if bakCount := countBackups(entries); bakCount != 0 {
+		t.Fatalf("expected no backup for current config, got %d", bakCount)
+	}
+
+	// File should be unchanged.
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != input {
+		t.Fatalf("file was modified when it shouldn't have been:\n%s", data)
+	}
+}
+
+func TestMigrateNonExistentFile(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "does-not-exist.toml")
+
+	// Should return nil, not error.
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("expected nil for non-existent file, got: %v", err)
+	}
+}
+
+func TestMigratePreservesFilePermissions(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `log_level = "info"
+
+[daemon]
+webhook_port = 9847
+`
+	if err := os.WriteFile(cfgPath, []byte(input), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Migrated file should preserve permissions.
+	info, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected config permissions 0600, got %04o", perm)
+	}
+
+	// Backup file should also preserve source permissions.
+	entries, _ := os.ReadDir(tmp)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			bakInfo, err := os.Stat(filepath.Join(tmp, e.Name()))
+			if err != nil {
+				t.Fatalf("stat backup: %v", err)
+			}
+			if perm := bakInfo.Mode().Perm(); perm != 0o600 {
+				t.Fatalf("expected backup permissions 0600, got %04o", perm)
+			}
+		}
+	}
+}
+
+func TestMigrateBackupStripsGroupOtherBits(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	input := `log_level = "info"
+
+[daemon]
+webhook_port = 9847
+`
+	// Source file is world-readable (0644).
+	if err := os.WriteFile(cfgPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := MigrateConfigFile(cfgPath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Migrated config keeps original permissions.
+	info, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("expected config permissions 0644, got %04o", perm)
+	}
+
+	// Backup should have group/other bits stripped (0644 & 0700 = 0600).
+	entries, _ := os.ReadDir(tmp)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			bakInfo, err := os.Stat(filepath.Join(tmp, e.Name()))
+			if err != nil {
+				t.Fatalf("stat backup: %v", err)
+			}
+			if perm := bakInfo.Mode().Perm(); perm != 0o600 {
+				t.Fatalf("expected backup permissions 0600, got %04o", perm)
+			}
+		}
+	}
+}
+
+func countBackups(entries []os.DirEntry) int {
+	count := 0
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/issuesync/syncer.go
+++ b/internal/issuesync/syncer.go
@@ -19,23 +19,25 @@ type Syncer struct {
 	store *db.Store
 	jobCh chan<- string
 
-	findGitHubPRByBranch func(ctx context.Context, token, owner, repo, head, state string) (string, error)
-	findGitLabMRByBranch func(ctx context.Context, token, baseURL, projectID, sourceBranch, state string) (string, error)
-	checkGitHubPRStatus  func(ctx context.Context, token, prURL string) (git.PRMergeStatus, error)
-	checkGitLabMRStatus  func(ctx context.Context, token, baseURL, mrURL string) (git.PRMergeStatus, error)
-	deleteRemoteBranch   func(ctx context.Context, dir, branchName string) error
+	findGitHubPRByBranch     func(ctx context.Context, token, owner, repo, head, state string) (string, error)
+	findGitLabMRByBranch     func(ctx context.Context, token, baseURL, projectID, sourceBranch, state string) (string, error)
+	checkGitHubPRStatus      func(ctx context.Context, token, prURL string) (git.PRMergeStatus, error)
+	checkGitLabMRStatus      func(ctx context.Context, token, baseURL, mrURL string) (git.PRMergeStatus, error)
+	deleteRemoteBranch       func(ctx context.Context, dir, branchName string) error
+	getGitHubCheckRunStatus  func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error)
 }
 
 func NewSyncer(cfg *config.Config, store *db.Store, jobCh chan<- string) *Syncer {
 	return &Syncer{
-		cfg:                  cfg,
-		store:                store,
-		jobCh:                jobCh,
-		findGitHubPRByBranch: git.FindGitHubPRByBranch,
-		findGitLabMRByBranch: git.FindGitLabMRByBranch,
-		checkGitHubPRStatus:  git.CheckGitHubPRStatus,
-		checkGitLabMRStatus:  git.CheckGitLabMRStatus,
-		deleteRemoteBranch:   git.DeleteRemoteBranch,
+		cfg:                     cfg,
+		store:                   store,
+		jobCh:                   jobCh,
+		findGitHubPRByBranch:    git.FindGitHubPRByBranch,
+		findGitLabMRByBranch:    git.FindGitLabMRByBranch,
+		checkGitHubPRStatus:     git.CheckGitHubPRStatus,
+		checkGitLabMRStatus:     git.CheckGitLabMRStatus,
+		deleteRemoteBranch:      git.DeleteRemoteBranch,
+		getGitHubCheckRunStatus: git.GetGitHubCheckRunStatus,
 	}
 }
 
@@ -173,7 +175,7 @@ func (s *Syncer) checkPRStatus(ctx context.Context) {
 			prURL, lookupErr = s.findGitLabMRByBranch(
 				ctx,
 				s.cfg.Tokens.GitLab,
-				normalizeGitLabBaseURL(proj.GitLab.BaseURL),
+				git.NormalizeGitLabBaseURL(proj.GitLab.BaseURL),
 				proj.GitLab.ProjectID,
 				branchName,
 				"all",
@@ -204,6 +206,12 @@ func (s *Syncer) checkPRStatus(ctx context.Context) {
 }
 
 func (s *Syncer) checkAndApplyPRStatus(ctx context.Context, job db.Job, proj *config.ProjectConfig) {
+	if s.applyTerminalPRStatus(ctx, job, proj) {
+		return
+	}
+}
+
+func (s *Syncer) applyTerminalPRStatus(ctx context.Context, job db.Job, proj *config.ProjectConfig) bool {
 	var (
 		status   git.PRMergeStatus
 		checkErr error
@@ -212,26 +220,26 @@ func (s *Syncer) checkAndApplyPRStatus(ctx context.Context, job db.Job, proj *co
 	switch {
 	case proj.GitHub != nil && strings.Contains(job.PRURL, "/pull/"):
 		if s.cfg.Tokens.GitHub == "" {
-			return
+			return false
 		}
 		status, checkErr = s.checkGitHubPRStatus(ctx, s.cfg.Tokens.GitHub, job.PRURL)
 	case proj.GitLab != nil && strings.Contains(job.PRURL, "/merge_requests/"):
 		if s.cfg.Tokens.GitLab == "" {
-			return
+			return false
 		}
 		status, checkErr = s.checkGitLabMRStatus(
 			ctx,
 			s.cfg.Tokens.GitLab,
-			normalizeGitLabBaseURL(proj.GitLab.BaseURL),
+			git.NormalizeGitLabBaseURL(proj.GitLab.BaseURL),
 			job.PRURL,
 		)
 	default:
-		return
+		return false
 	}
 
 	if checkErr != nil {
 		slog.Warn("check PR status failed", "job", job.ID, "err", checkErr)
-		return
+		return false
 	}
 
 	if status.Merged {
@@ -241,11 +249,11 @@ func (s *Syncer) checkAndApplyPRStatus(ctx context.Context, job db.Job, proj *co
 		}
 		if err := s.store.MarkJobMerged(ctx, job.ID, mergedAt); err != nil {
 			slog.Error("mark job merged", "job", job.ID, "err", err)
-			return
+			return false
 		}
 		slog.Info("PR merged", "job", db.ShortID(job.ID), "pr_url", job.PRURL)
 		s.cleanupWorktree(ctx, job)
-		return
+		return true
 	}
 
 	if status.Closed {
@@ -255,11 +263,14 @@ func (s *Syncer) checkAndApplyPRStatus(ctx context.Context, job db.Job, proj *co
 		}
 		if err := s.store.MarkJobPRClosed(ctx, job.ID, closedAt); err != nil {
 			slog.Error("mark job PR closed", "job", job.ID, "err", err)
-			return
+			return false
 		}
 		slog.Info("PR closed", "job", db.ShortID(job.ID), "pr_url", job.PRURL)
 		s.cleanupWorktree(ctx, job)
+		return true
 	}
+
+	return false
 }
 
 // cleanupWorktree removes the job's worktree directory and clears the DB field.
@@ -281,12 +292,118 @@ func (s *Syncer) cleanupWorktree(ctx context.Context, job db.Job) {
 	slog.Info("worktree cleaned up", "job", db.ShortID(job.ID), "path", job.WorktreePath)
 }
 
-func normalizeGitLabBaseURL(baseURL string) string {
-	baseURL = strings.TrimSpace(baseURL)
-	if baseURL == "" {
-		return "https://gitlab.com"
+// CheckCIStatus polls GitHub check-runs for all awaiting_checks jobs and
+// transitions them to approved (all passed) or rejected (any failed / timeout).
+func (s *Syncer) CheckCIStatus(ctx context.Context) {
+	ciTimeout, _ := time.ParseDuration(s.cfg.Daemon.CICheckTimeout)
+	if ciTimeout <= 0 {
+		ciTimeout = 30 * time.Minute
 	}
-	return strings.TrimRight(baseURL, "/")
+
+	jobs, err := s.store.ListAwaitingChecksJobs(ctx)
+	if err != nil {
+		slog.Error("check CI status: list awaiting_checks jobs", "err", err)
+		return
+	}
+	if len(jobs) == 0 {
+		return
+	}
+
+	slog.Debug("checking CI status", "job_count", len(jobs))
+
+	for _, job := range jobs {
+		proj, ok := s.cfg.ProjectByName(job.ProjectName)
+		if !ok {
+			continue
+		}
+
+		// Non-GitHub projects: auto-approve (CI polling not supported).
+		if proj.GitHub == nil {
+			if err := s.store.TransitionState(ctx, job.ID, "awaiting_checks", "approved"); err != nil {
+				slog.Error("check CI: auto-approve non-GitHub job", "job", job.ID, "err", err)
+			}
+			continue
+		}
+
+		// Handle PR close/merge before CI evaluation and timeout.
+		if s.applyTerminalPRStatus(ctx, job, proj) {
+			continue
+		}
+
+		// Timeout check.
+		updatedAt, ok := parseTimestamp(job.UpdatedAt)
+		if ok && time.Since(updatedAt) > ciTimeout {
+			reason := fmt.Sprintf("CI check timeout: no result after %s", ciTimeout)
+			if err := s.store.RejectJob(ctx, job.ID, "awaiting_checks", reason); err != nil {
+				slog.Error("check CI: reject timed-out job", "job", job.ID, "err", err)
+			} else {
+				slog.Info("CI checks timed out", "job", db.ShortID(job.ID))
+			}
+			continue
+		}
+
+		// Prefer commit SHA for accuracy; fall back to branch name.
+		ref := strings.TrimSpace(job.CommitSHA)
+		if ref == "" {
+			ref = strings.TrimSpace(job.BranchName)
+		}
+		if s.cfg.Tokens.GitHub == "" || ref == "" {
+			continue
+		}
+
+		status, err := s.getGitHubCheckRunStatus(ctx, s.cfg.Tokens.GitHub, proj.GitHub.Owner, proj.GitHub.Repo, ref)
+		if err != nil {
+			slog.Warn("check CI: get check-run status", "job", job.ID, "err", err)
+			continue
+		}
+
+		// No checks registered yet — wait for next poll.
+		if status.Total == 0 {
+			continue
+		}
+
+		// Any failed check → reject.
+		if status.Failed > 0 {
+			reason := fmt.Sprintf("CI check failed: %s", status.FailedCheckName)
+			if status.FailedCheckURL != "" {
+				reason += " (" + status.FailedCheckURL + ")"
+			}
+			if err := s.store.RejectJob(ctx, job.ID, "awaiting_checks", reason); err != nil {
+				slog.Error("check CI: reject failed job", "job", job.ID, "err", err)
+			} else {
+				slog.Info("CI check failed", "job", db.ShortID(job.ID), "check", status.FailedCheckName)
+			}
+			continue
+		}
+
+		// All completed and passed → approve.
+		if status.Pending == 0 && status.Passed > 0 {
+			if err := s.store.TransitionState(ctx, job.ID, "awaiting_checks", "approved"); err != nil {
+				slog.Error("check CI: approve job", "job", job.ID, "err", err)
+			} else {
+				slog.Info("CI checks passed", "job", db.ShortID(job.ID), "passed", status.Passed)
+			}
+			continue
+		}
+
+		// Still pending — wait for next poll cycle.
+	}
+}
+
+// parseTimestamp parses an RFC3339 timestamp string.
+func parseTimestamp(ts string) (time.Time, bool) {
+	ts = strings.TrimSpace(ts)
+	if ts == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			return time.Time{}, false
+		}
+	}
+	return t, true
 }
 
 func (s *Syncer) cancelJobsForClosedIssue(ctx context.Context, projectName, source, sourceIssueID, autoprIssueID string) {

--- a/internal/issuesync/syncer_ci_test.go
+++ b/internal/issuesync/syncer_ci_test.go
@@ -1,0 +1,354 @@
+package issuesync
+
+import (
+	"context"
+	"testing"
+
+	"autopr/internal/config"
+	"autopr/internal/git"
+)
+
+func TestCheckCIStatus_AllChecksPassed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-passed", "awaiting_checks", "autopr/ci-pass", "https://github.com/acme/repo/pull/100")
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "30m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		if ref != "autopr/ci-pass" {
+			t.Fatalf("unexpected ref: %q", ref)
+		}
+		return git.CheckRunStatus{
+			Total:     3,
+			Completed: 3,
+			Passed:    3,
+		}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != "approved" {
+		t.Fatalf("expected job state approved, got %q", job.State)
+	}
+}
+
+func TestCheckCIStatus_CheckFailed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-failed", "awaiting_checks", "autopr/ci-fail", "https://github.com/acme/repo/pull/101")
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "30m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		return git.CheckRunStatus{
+			Total:           2,
+			Completed:       2,
+			Passed:          1,
+			Failed:          1,
+			FailedCheckName: "lint",
+			FailedCheckURL:  "https://github.com/acme/repo/runs/999",
+		}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != "rejected" {
+		t.Fatalf("expected job state rejected, got %q", job.State)
+	}
+	if job.RejectReason == "" {
+		t.Fatalf("expected reject_reason to be set")
+	}
+}
+
+func TestCheckCIStatus_Pending(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-pending", "awaiting_checks", "autopr/ci-pend", "https://github.com/acme/repo/pull/102")
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "30m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		return git.CheckRunStatus{
+			Total:     3,
+			Completed: 1,
+			Passed:    1,
+			Pending:   2,
+		}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != "awaiting_checks" {
+		t.Fatalf("expected job to remain awaiting_checks, got %q", job.State)
+	}
+}
+
+func TestCheckCIStatus_NoChecksYet(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-nochecks", "awaiting_checks", "autopr/ci-none", "https://github.com/acme/repo/pull/103")
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "30m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		return git.CheckRunStatus{Total: 0}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != "awaiting_checks" {
+		t.Fatalf("expected job to remain awaiting_checks, got %q", job.State)
+	}
+}
+
+func TestCheckCIStatus_AwaitingChecksPRMergedBeforeTimeout(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-merged", "awaiting_checks", "autopr/ci-merged", "https://github.com/acme/repo/pull/105")
+
+	if _, err := store.Writer.ExecContext(ctx, `
+UPDATE jobs SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-2 hours')
+	WHERE id = ?`, jobID); err != nil {
+		t.Fatalf("set old updated_at: %v", err)
+	}
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "1m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.checkGitHubPRStatus = func(ctx context.Context, token, prURL string) (git.PRMergeStatus, error) {
+		if token != "token" {
+			t.Fatalf("unexpected token: %q", token)
+		}
+		if prURL != "https://github.com/acme/repo/pull/105" {
+			t.Fatalf("unexpected PR URL: %q", prURL)
+		}
+		return git.PRMergeStatus{Merged: true, MergedAt: "2026-02-18T12:00:00Z"}, nil
+	}
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		t.Fatalf("CI check should not run after merged PR is detected")
+		return git.CheckRunStatus{}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.PRMergedAt != "2026-02-18T12:00:00Z" {
+		t.Fatalf("expected merged timestamp, got %q", job.PRMergedAt)
+	}
+	if job.State != "awaiting_checks" {
+		t.Fatalf("expected job to remain awaiting_checks, got %q", job.State)
+	}
+	if job.RejectReason != "" {
+		t.Fatalf("expected no reject reason for merged job, got %q", job.RejectReason)
+	}
+}
+
+func TestCheckCIStatus_AwaitingChecksPRClosedBeforeTimeout(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-closed", "awaiting_checks", "autopr/ci-closed", "https://github.com/acme/repo/pull/106")
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "1m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.checkGitHubPRStatus = func(ctx context.Context, token, prURL string) (git.PRMergeStatus, error) {
+		if token != "token" {
+			t.Fatalf("unexpected token: %q", token)
+		}
+		if prURL != "https://github.com/acme/repo/pull/106" {
+			t.Fatalf("unexpected PR URL: %q", prURL)
+		}
+		return git.PRMergeStatus{Closed: true, ClosedAt: "2026-02-18T12:01:00Z"}, nil
+	}
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		t.Fatalf("CI check should not run after closed PR is detected")
+		return git.CheckRunStatus{}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.PRClosedAt != "2026-02-18T12:01:00Z" {
+		t.Fatalf("expected closed timestamp, got %q", job.PRClosedAt)
+	}
+	if job.State != "awaiting_checks" {
+		t.Fatalf("expected job to remain awaiting_checks, got %q", job.State)
+	}
+	if job.RejectReason != "" {
+		t.Fatalf("expected no reject reason for closed job, got %q", job.RejectReason)
+	}
+}
+
+func TestCheckCIStatus_Timeout(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gh", "ci-timeout", "awaiting_checks", "autopr/ci-timeout", "https://github.com/acme/repo/pull/104")
+
+	// Set updated_at to 2 hours ago to trigger timeout.
+	if _, err := store.Writer.ExecContext(ctx, `
+UPDATE jobs SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-2 hours')
+WHERE id = ?`, jobID); err != nil {
+		t.Fatalf("set old updated_at: %v", err)
+	}
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitHub: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "1m"}, // 1 minute timeout
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gh",
+				GitHub: &config.ProjectGitHub{Owner: "acme", Repo: "repo"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		t.Fatalf("check-run status should not be called for timed-out job")
+		return git.CheckRunStatus{}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != "rejected" {
+		t.Fatalf("expected job state rejected after timeout, got %q", job.State)
+	}
+	if job.RejectReason == "" {
+		t.Fatalf("expected reject_reason for timeout")
+	}
+}
+
+func TestCheckCIStatus_NonGitHub(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t)
+	defer store.Close()
+
+	jobID := createSyncTestJob(t, ctx, store, "project-gl", "ci-nongithub", "awaiting_checks", "autopr/ci-gl", "https://gitlab.com/org/repo/-/merge_requests/50")
+
+	cfg := &config.Config{
+		Tokens: config.TokensConfig{GitLab: "token"},
+		Daemon: config.DaemonConfig{CICheckTimeout: "30m"},
+		Projects: []config.ProjectConfig{
+			{
+				Name:   "project-gl",
+				GitLab: &config.ProjectGitLab{ProjectID: "123"},
+			},
+		},
+	}
+	s := NewSyncer(cfg, store, make(chan string, 1))
+	s.getGitHubCheckRunStatus = func(ctx context.Context, token, owner, repo, ref string) (git.CheckRunStatus, error) {
+		t.Fatalf("GitHub check-run status should not be called for GitLab project")
+		return git.CheckRunStatus{}, nil
+	}
+
+	s.CheckCIStatus(ctx)
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	// Non-GitHub projects should be auto-approved.
+	if job.State != "approved" {
+		t.Fatalf("expected non-GitHub job to be auto-approved, got %q", job.State)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -46,6 +46,8 @@ var (
 		"rebasing":            lipgloss.NewStyle().Foreground(lipgloss.Color("135")),
 		"resolving":           lipgloss.NewStyle().Foreground(lipgloss.Color("202")),
 		"resolving_conflicts": lipgloss.NewStyle().Foreground(lipgloss.Color("202")),
+		"checking ci":        lipgloss.NewStyle().Foreground(lipgloss.Color("33")),
+		"awaiting_checks":    lipgloss.NewStyle().Foreground(lipgloss.Color("33")),
 		"approved":            lipgloss.NewStyle().Foreground(lipgloss.Color("40")),
 		"merged":              lipgloss.NewStyle().Foreground(lipgloss.Color("141")),
 		"pr closed":           lipgloss.NewStyle().Foreground(lipgloss.Color("208")),
@@ -76,6 +78,7 @@ var filterStateCycle = []string{
 	filterAllState,
 	"queued",
 	"active",
+	"awaiting_checks",
 	"rebasing",
 	"resolving_conflicts",
 	"ready",
@@ -1292,7 +1295,7 @@ func (m Model) listView() string {
 	// Job state counters.
 	counts := m.jobCounts()
 	active := counts["planning"] + counts["implementing"] + counts["reviewing"] + counts["testing"] +
-		counts["rebasing"] + counts["resolving_conflicts"]
+		counts["rebasing"] + counts["resolving_conflicts"] + counts["awaiting_checks"]
 	b.WriteString(fmt.Sprintf("  %s %d   %s %d   %s %d   %s %d   %s %d\n",
 		labelStyle.Render("queued"), counts["queued"],
 		labelStyle.Render("active"), active,

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -550,7 +550,7 @@ func TestFilterModeCycleStateAndProject(t *testing.T) {
 	modelAny, _ := m.handleKey(keyRunes('f'))
 	m = modelAny.(Model)
 
-	expectedStates := []string{"queued", "active", "rebasing", "resolving_conflicts", "ready", "failed", "merged", "rejected", "cancelled", "all"}
+	expectedStates := []string{"queued", "active", "awaiting_checks", "rebasing", "resolving_conflicts", "ready", "failed", "merged", "rejected", "cancelled", "all"}
 	for _, state := range expectedStates {
 		modelAny, _ = m.handleKey(keyRunes('s'))
 		m = modelAny.(Model)


### PR DESCRIPTION
## Summary
- Add CI check-run polling for GitHub PRs after creation, transitioning jobs through a new `awaiting_checks` state
- Introduce configurable `ci_check_interval` (default 30s) and `ci_check_timeout` (default 30m) in daemon config
- Add config versioning with automatic migration from v0 to v1
- Add DB schema migration to support the new `awaiting_checks` job state
- Wire up the daemon sync loop to monitor check-run results and surface failures

Closes #80

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race -count=1 ./...`)
- [x] Static analysis clean (`go vet ./...`)
- [ ] Manual test: create a PR on a repo with CI checks and verify polling behavior
- [ ] Manual test: verify config migration from old format to new versioned format
- [ ] Manual test: verify timeout behavior when CI checks hang