### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-const Version = "0.7.0"
+const Version = "0.8.0"
 
 // Credentials holds tokens loaded from credentials.toml.
 type Credentials struct {


### PR DESCRIPTION
## Summary
- Bump version to 0.8.0 for CI check polling release

## Test plan
- [x] All tests pass
- [x] Binary builds for both darwin/arm64 and darwin/amd64