### PR TITLE
[AutoPR] fix: ap retry should increment iteration counter to separate old and new pipeline runs

### DIFF
--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -497,7 +497,7 @@ func (s *Store) IncrementIteration(ctx context.Context, jobID string) error {
 // ResetJobForRetry resets a failed/rejected/cancelled job to queued with fresh state.
 func (s *Store) ResetJobForRetry(ctx context.Context, jobID, notes string) error {
 	res, err := s.Writer.ExecContext(ctx, `
-UPDATE jobs SET state = 'queued', iteration = 0, worktree_path = NULL, branch_name = NULL,
+UPDATE jobs SET state = 'queued', iteration = iteration + 1, worktree_path = NULL, branch_name = NULL,
                commit_sha = NULL, error_message = NULL, human_notes = ?,
                started_at = NULL, completed_at = NULL,
                updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/73

**Issue:** fix: ap retry should increment iteration counter to separate old and new pipeline runs

<details>
<summary>Plan</summary>

## Implementation plan

### 1) Files to modify
1. `internal/db/jobs.go`  
2. `internal/db/db_test.go`  

No new files expected.

### 2) `internal/db/jobs.go` change (core fix)
1. In `Store.ResetJobForRetry` (`internal/db/jobs.go`, around current `UPDATE jobs SET state = 'queued', iteration = 0 ...`):
   - Change `iteration = 0` to `iteration = iteration + 1`.
   - Keep all other reset fields as-is (`state`, `worktree_path`, `branch_name`, `commit_sha`, `error_message`, timestamps, sibling/eligibility gate logic).
2. Keep error handling unchanged so blocked retries still fail exactly as before.
3. Ensure the SQL update still only applies when state is retry-eligible and there is no active sibling job.

Suggested intent change (conceptually):
- Old: each retry starts a fresh run but reuses the same `iteration`.
- New: each retry creates a new iteration namespace, so new sessions are grouped separately in TUI.

### 3) `internal/db/db_test.go` test updates
1. Update existing successful-retry test(s) to assert iteration is incremented:
   - `TestResetJobForRetryFromCancelled`:
     - Fetch job before retry, assert initial `Iteration` (usually 0).
     - Call `ResetJobForRetry`.
     - Fetch job after retry, assert:
       - `state == "queued"`
       - `Iteration == initial + 1`
       - existing reset fields still cleared as expected.
2. Update or add assertion coverage for already-nonzero iteration:
   - Add/adjust a test near existing retry tests so a job with `Iteration = 2` retries to `Iteration = 3`.
   - This avoids regressions from hardcoding `0`.
3. Add a negative test assertion variant (near `TestResetJobForRetryBlockedWhenIssueIneligible` or `TestResetJobForRetryBlockedByActiveSibling`):
   - Assert blocked retry attempts do **not** alter `Iteration` and leave job unchanged apart from retry rejection.
4. If there is already a test in this area with the “valid failure retry path” comment around line ~171, extend it similarly for `Iteration` to maximize cove

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `3d455b0a`_
