### PR TITLE
[AutoPR] Improve UX of start/stop/status CLI output

### DIFF
--- a/cmd/autopr/cli/start.go
+++ b/cmd/autopr/cli/start.go
@@ -151,7 +151,7 @@ func runBackground(cfg *config.Config) error {
 		// Still running after 500ms — detach and let it go.
 	}
 
-	fmt.Printf("Daemon started (pid %d), log: %s\n", child.Process.Pid, logPath)
+	fmt.Printf("Daemon started. Log: %s\n", logPath)
 	return nil
 }
 

--- a/cmd/autopr/cli/stop.go
+++ b/cmd/autopr/cli/stop.go
@@ -52,8 +52,6 @@ func runStop(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("signal process %d: %w", pid, err)
 	}
 
-	fmt.Printf("Stopping daemon (pid %d)...\n", pid)
-
 	// Wait for process to exit.
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
@@ -68,7 +66,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 	// Force kill.
 	_ = proc.Signal(syscall.SIGKILL)
 	daemon.RemovePID(cfg.Daemon.PIDFile)
-	fmt.Println("Daemon killed (did not stop gracefully).")
+	fmt.Println("Daemon stopped (forced).")
 	printStopServiceKeepAliveNote(cfg)
 	return nil
 }


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/122

**Issue:** Improve UX of start/stop/status CLI output

<details>
<summary>Plan</summary>

## 1) Files to modify

- `cmd/autopr/cli/status.go`
- `cmd/autopr/cli/stop.go`
- `cmd/autopr/cli/start.go`
- `cmd/autopr/cli/status_test.go` (update existing expectations; add/adjust coverage)

No new files required.

## 2) Specific changes per file

1. `cmd/autopr/cli/status.go`
1. Keep existing DB query and JSON assembly unchanged so `--json` output and `statusOutput` shape are untouched.
1. Replace the `Jobs:` single-line `fmt.Printf` block with grouped, aligned CLI formatting only in the non-JSON path.
1. Add a local, deterministic section builder (ordered, not map-random) for:
   - `Pipeline`: `queued`, `active`
   - `Active`: `planning`, `implementing`, `reviewing`, `testing`
   - `Output`: `needs_pr`, `merged`, `pr_created`
   - `Problems`: `failed`, `rejected`, `cancelled`
1. Compute `active` using the same semantics as today:
   - `planning + implementing + reviewing + testing + rebasing + resolving_conflicts`
   - keep this exact behavior to avoid count drift.
1. Print only sections where at least one value is non-zero.
1. Print with aligned labels and `·` separators (`strings.Join` style), while preserving exact text case and style from the proposal.
1. Keep existing daemon line text:
   - `Daemon: running (PID %s)` when running
   - `Daemon: stopped` otherwise
1. Optional format helper to keep clarity:
   - `renderStatusSection(title string, values []kv) (string, bool)` returns rendered line + `hasNonZero`.
   - Use constants for separator and label width to keep output stable.

1. `cmd/autopr/cli/stop.go`
1. Replace graceful-stop message:
   - from `Stopping daemon (pid %d)...`
   - to no preamble message (as requested).
1. Replace graceful success message to:
   - `Daemon stopped.`
1. Replace forced stop message to:
   - `Daemon stopped (forced).`
1. Keep PID removal, SIGTERM/SIGKILL flow, and `printStopServiceKeepAliveNote` calls unchanged.

1. `cmd/autopr/cli/start.go`
1. Replace:
   - `Daemon started (pid %d), log: %s`
   - with:
   - `Daemon start

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `47edf937`_
