### PR TITLE
[AutoPR] bug: daemon creates duplicate jobs for issues with cancelled/rejected jobs

### DIFF
--- a/internal/issuesync/syncer.go
+++ b/internal/issuesync/syncer.go
@@ -93,14 +93,14 @@ func (s *Syncer) syncProject(ctx context.Context, p *config.ProjectConfig) error
 	return nil
 }
 
-// createJobIfNeeded creates a job for an issue if there isn't already an active one.
+// createJobIfNeeded creates a job for an issue if there isn't already a non-merged one.
 func (s *Syncer) createJobIfNeeded(ctx context.Context, ffid, projectName string) {
-	active, err := s.store.HasActiveJobForIssue(ctx, ffid)
+	exists, err := s.store.HasAnyNonMergedJobForIssue(ctx, ffid)
 	if err != nil {
-		slog.Error("sync: check active job", "err", err)
+		slog.Error("sync: check existing job", "err", err)
 		return
 	}
-	if active {
+	if exists {
 		return
 	}
 


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/146

**Issue:** bug: daemon creates duplicate jobs for issues with cancelled/rejected jobs

<details>
<summary>Plan</summary>

Implementation plan

1) Files to modify/create

- `internal/db/jobs.go`
- `internal/issuesync/syncer.go`
- `internal/db/db_test.go`
- `internal/issuesync/syncer_test.go`

2) `internal/db/jobs.go` changes

1. Add new method on `Store`:
- `HasAnyNonMergedJobForIssue(ctx context.Context, autoprIssueID string) (bool, error)`

2. Use query matching required semantics:
- Return true when ANY job exists for the issue that is not fully completed/closed.
- Concrete rule:
  - true for `state != 'approved'`
  - OR `state = 'approved'` and `pr_merged_at` is NULL/empty
    and `pr_closed_at` is NULL/empty
- Keep NULL + empty-string checks in SQL for compatibility with current storage patterns.

3. Keep existing `HasActiveJobForIssue` unchanged (explicitly do not alter), since retry logic depends on it.

3) `internal/issuesync/syncer.go` changes

1. In `createJobIfNeeded`, replace:
- `HasActiveJobForIssue` check with `HasAnyNonMergedJobForIssue`.

2. Preserve existing behavior after the guard:
- If check returns true, return without creating.
- If check returns false, continue existing job creation flow unchanged.

3) Test updates — `internal/db/db_test.go`

1. Add focused unit tests for new helper:
- true when issue has `cancelled` job
- true when issue has `rejected` job
- true when issue has `failed` job
- false when only job is `approved` + `pr_merged_at` set
- false when no jobs exist for issue

2. Include explicit setup/assertions for storage edge formats:
- `pr_merged_at`/`pr_closed_at` as `NULL`
- and empty string `""` where test fixtures represent unset timestamps this way.

4) Test updates — `internal/issuesync/syncer_test.go`

1. Add/adjust tests in existing syncer test flow:
- sync should NOT create a new job when an existing same-issue `cancelled` job exists
- sync should NOT create a new job when an existing same-issue `rejected` job exists
- sync SHOULD create a new job when only existing same-issue job is `approved` with merged PR state

2. Ensure test style m

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `4382610a`_
