### PR TITLE
[AutoPR] TUI: add subtle background highlight to selected table row

### DIFF
--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 )
+
+var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func TestFilterGhostSessions(t *testing.T) {
 	sessions := []db.LLMSessionSummary{
@@ -51,6 +54,91 @@ func TestSelectedStyleRendersBackgroundInANSI256(t *testing.T) {
 	if !strings.Contains(rendered, "48;5;236") {
 		t.Fatalf("expected selectedStyle to render ANSI256 background 236, got: %q", rendered)
 	}
+}
+
+func TestListViewSelectedRowKeepsBackgroundAcrossStyledCells(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	job := db.Job{
+		ID:            "ap-job-1234",
+		State:         "ready",
+		ProjectName:   "proj",
+		IssueSource:   "github",
+		SourceIssueID: "42",
+		IssueTitle:    "selected row background",
+		UpdatedAt:     "2025-02-19T14:04:05Z",
+	}
+	m := Model{
+		cfg: &config.Config{
+			Daemon: config.DaemonConfig{
+				SyncInterval: "5m",
+				MaxWorkers:   1,
+			},
+		},
+		jobs:   []db.Job{job},
+		cursor: 0,
+	}
+
+	line := findLineContainingText(t, m.listView(), db.ShortID(job.ID))
+	if !strings.Contains(stripANSI(line), "> ") {
+		t.Fatalf("expected selected cursor marker in line, got: %q", stripANSI(line))
+	}
+	if got := strings.Count(line, "48;5;236"); got < 3 {
+		t.Fatalf("expected selected row background to be reapplied across styled cells, got %d: %q", got, line)
+	}
+}
+
+func TestDetailViewSelectedPipelineRowKeepsBackgroundAcrossStyledCells(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	job := db.Job{
+		ID:          "ap-job-1234",
+		State:       "implementing",
+		ProjectName: "proj",
+	}
+	m := Model{
+		selected: &job,
+		sessions: []db.LLMSessionSummary{
+			{
+				ID:           1,
+				Step:         "plan",
+				Status:       "completed",
+				LLMProvider:  "codex",
+				InputTokens:  1,
+				OutputTokens: 2,
+				DurationMS:   3000,
+				CreatedAt:    "2025-02-19T14:01:02Z",
+			},
+		},
+		sessCursor: 0,
+	}
+
+	line := findLineContainingText(t, m.detailView(), "codex")
+	if !strings.Contains(stripANSI(line), "> ") {
+		t.Fatalf("expected selected cursor marker in line, got: %q", stripANSI(line))
+	}
+	if got := strings.Count(line, "48;5;236"); got < 3 {
+		t.Fatalf("expected selected pipeline row background to be reapplied across styled cells, got %d: %q", got, line)
+	}
+}
+
+func stripANSI(s string) string {
+	return ansiRegexp.ReplaceAllString(s, "")
+}
+
+func findLineContainingText(t *testing.T, view, want string) string {
+	t.Helper()
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(stripANSI(line), want) {
+			return line
+		}
+	}
+	t.Fatalf("could not find line containing %q in:\n%s", want, view)
+	return ""
 }
 
 func TestListViewShowsFilterIndicatorAndFooterHints(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/65

**Issue:** TUI: add subtle background highlight to selected table row

<details>
<summary>Plan</summary>

**Implementation Plan**

1. **Files to modify**
1. `internal/tui/model.go`
1. `internal/tui/model_test.go` (optional but recommended for style regression guard)
1. No new files required.

2. **Specific changes**
1. `internal/tui/model.go:34`
- Update `selectedStyle` to include subtle background:
```go
selectedStyle = lipgloss.NewStyle().
    Bold(true).
    Foreground(lipgloss.Color("46")).
    Background(lipgloss.Color("236")) // or 235 if you want darker
```
- Keep usage sites unchanged (`listView`/`detailView` already call `selectedStyle.Render(line)` at `internal/tui/model.go:1531`, `1718`, `1748`, `1786`, `1816`, `1849`, `1885`).

1. `internal/tui/model_test.go` (optional)
- Add a focused test that `selectedStyle` renders a background ANSI code when ANSI256 is enabled.
- This is only to prevent accidental removal of background in future refactors.

3. **Potential risks / edge cases**
1. **ANSI reset interaction**: rows include nested styled segments (`stateStyle.Render`, `dimStyle.Render`). Those insert reset codes, so an outer row background may not persist across the full row in all terminals.
1. **Terminal theme variance**: `236` may be too low-contrast on some light themes.
1. **Color profile variance**: 16-color terminals may remap `236` unexpectedly.

4. **Testing strategy**
1. **Automated**
- Run: `GOCACHE=/tmp/go-cache go test ./internal/tui`
- If adding the optional style test, include it in same package run above.
1. **Manual visual verification (required for this UI change)**
- Launch TUI.
- In job list (level 1), move selection through rows with mixed states; confirm selected row is immediately identifiable.
- Enter detail view (level 2), move through session/pipeline rows; confirm same highlight behavior.
- Confirm non-selected rows unchanged.
1. **Acceptance check**
- If highlight looks partial due nested ANSI resets, follow-up patch should apply background per cell style, not only outer row wrapper.
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `6f3c983d`_
