### PR TITLE
[AutoPR] feat: show 'checking ci' as a pipeline step in TUI job detail view

### DIFF
--- a/internal/issuesync/syncer_ci_test.go
+++ b/internal/issuesync/syncer_ci_test.go
@@ -2,6 +2,7 @@ package issuesync
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"autopr/internal/config"
@@ -47,6 +48,9 @@ func TestCheckCIStatus_AllChecksPassed(t *testing.T) {
 	if job.State != "approved" {
 		t.Fatalf("expected job state approved, got %q", job.State)
 	}
+	if job.CIStatusSummary == "" || !strings.Contains(job.CIStatusSummary, "passed") {
+		t.Fatalf("expected CI summary to include pass details, got %q", job.CIStatusSummary)
+	}
 }
 
 func TestCheckCIStatus_CheckFailed(t *testing.T) {
@@ -91,6 +95,9 @@ func TestCheckCIStatus_CheckFailed(t *testing.T) {
 	if job.RejectReason == "" {
 		t.Fatalf("expected reject_reason to be set")
 	}
+	if job.CIStatusSummary == "" || !strings.Contains(job.CIStatusSummary, "lint") {
+		t.Fatalf("expected CI summary to include failed check details, got %q", job.CIStatusSummary)
+	}
 }
 
 func TestCheckCIStatus_Pending(t *testing.T) {
@@ -130,6 +137,9 @@ func TestCheckCIStatus_Pending(t *testing.T) {
 	if job.State != "awaiting_checks" {
 		t.Fatalf("expected job to remain awaiting_checks, got %q", job.State)
 	}
+	if job.CIStatusSummary == "" || !strings.Contains(job.CIStatusSummary, "pending=2") {
+		t.Fatalf("expected CI summary to include pending count, got %q", job.CIStatusSummary)
+	}
 }
 
 func TestCheckCIStatus_NoChecksYet(t *testing.T) {
@@ -163,6 +173,9 @@ func TestCheckCIStatus_NoChecksYet(t *testing.T) {
 	}
 	if job.State != "awaiting_checks" {
 		t.Fatalf("expected job to remain awaiting_checks, got %q", job.State)
+	}
+	if job.CIStatusSummary == "" || !strings.Contains(job.CIStatusSummary, "no check-runs") {
+		t.Fatalf("expected CI summary to mention no checks, got %q", job.CIStatusSummary)
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/156

**Issue:** feat: show 'checking ci' as a pipeline step in TUI job detail view

<details>
<summary>Plan</summary>

**Implementation Plan**

1. **Files to modify/create**

1. `internal/tui/model.go`
2. `internal/db/jobs.go`
3. `internal/tui/model_test.go`
4. Optional timing phase: `internal/db/schema.go`, `internal/db/jobs.go`, `internal/db/db_test.go`
5. Optional CI-details phase: `internal/issuesync/syncer.go`, `internal/git/pr.go` (if richer status needed), `internal/tui/model.go`, tests in `internal/issuesync/syncer_ci_test.go` and `internal/tui/model_test.go`

2. **Specific changes per file**

1. `internal/tui/model.go`
- Add a CI synthetic pipeline row renderer in job detail table (`internal/tui/model.go:1648+`), placed before existing `pr created` row.
- Add visibility helper for CI row (MVP condition): `job.PRURL != ""` and state indicates current/post-CI (`awaiting_checks`, `approved`, `rejected`; optionally `cancelled` if from awaiting checks).  
- Add status helper for CI row:
  - `awaiting_checks` -> `running`
  - `approved` (and merged/closed overlays) -> `completed`
  - `rejected` -> `failed`
  - `cancelled` -> `cancelled` (optional but recommended)
- Use existing `sessStatusStyle` for status coloring; no new style map needed.
- Update `stepCount` so CI row counts as a pipeline step.
- Update row index math in `handleKeyLevel2` (`internal/tui/model.go:1040+`) so cursor navigation and `enter` still map correctly after inserting CI row.
- Add `enterCheckingCIView()` synthetic detail view (similar to `enterPRView`/`enterMergedView`) and wire it in `handleKeyLevel2`.
- Update `sessionView()` numbering logic (`internal/tui/model.go:1936+`) to account for the new synthetic `checking ci` row.

2. `internal/db/jobs.go`
- Add `DisplayStep` mapping for CI synthetic step label:
  - e.g. `"awaiting_checks"` -> `"checking ci"` (or whichever step key you use in synthetic session).
- No state-machine change required for MVP row rendering.

3. `internal/tui/model_test.go`
- Add tests for CI row rendering:
  - row appears in `awaiting_checks`
  - row status is `running` in `awaiting

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `9be153df`_
