### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-const Version = "0.8.0"
+const Version = "0.9.0"
 
 // Credentials holds tokens loaded from credentials.toml.
 type Credentials struct {


### PR DESCRIPTION
## Summary
- Bump version to 0.9.0 for new release

## Test plan
- Version constant updated in `internal/config/config.go`