### PR TITLE
[AutoPR] fix: ap list shows "No jobs found." without a newline hint

### DIFF
--- a/cmd/autopr/cli/list.go
+++ b/cmd/autopr/cli/list.go
@@ -51,7 +51,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(jobs) == 0 {
-		fmt.Println("No jobs found.")
+		fmt.Println("No jobs found. Run 'ap start' to begin processing issues.")
 		return nil
 	}
 

--- a/cmd/autopr/cli/list_test.go
+++ b/cmd/autopr/cli/list_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunListNoJobsShowsStartHint(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := writeStatusConfig(t, tmp)
+
+	out := runListWithTestConfig(t, cfg, false)
+	got := strings.TrimSpace(out)
+	want := "No jobs found. Run 'ap start' to begin processing issues."
+	if got != want {
+		t.Fatalf("unexpected output: got %q, want %q", got, want)
+	}
+}
+
+func TestRunListNoJobsJSONStillWorks(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := writeStatusConfig(t, tmp)
+
+	out := runListWithTestConfig(t, cfg, true)
+	got := strings.TrimSpace(out)
+	if strings.Contains(got, "No jobs found.") {
+		t.Fatalf("unexpected human-readable message in JSON output: %q", got)
+	}
+
+	var jobs []map[string]any
+	if err := json.Unmarshal([]byte(got), &jobs); err != nil {
+		t.Fatalf("decode JSON jobs: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("expected no jobs in JSON output, got %d", len(jobs))
+	}
+}
+
+func runListWithTestConfig(t *testing.T, configPath string, asJSON bool) string {
+	t.Helper()
+	prevCfgPath := cfgPath
+	prevJSON := jsonOut
+	cfgPath = configPath
+	jsonOut = asJSON
+	t.Cleanup(func() {
+		cfgPath = prevCfgPath
+		jsonOut = prevJSON
+	})
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return captureStdout(t, func() error {
+		return runList(cmd, nil)
+	})
+}


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/149

**Issue:** fix: ap list shows "No jobs found." without a newline hint

<details>
<summary>Plan</summary>

## Implementation Plan

### 1) Files to modify/create

1. `cmd/autopr/cli/list.go` (modify)
   - Change the empty-result user-facing message in `runList`.
2. `cmd/autopr/cli/list_test.go` (create, optional but recommended)
   - Add regression tests for the empty-state output and JSON-mode behavior.

### 2) Specific code changes

1. Update empty-jobs branch in `cmd/autopr/cli/list.go` (`runList`, around line 54)
   - Replace:
     - `fmt.Println("No jobs found.")`
   - With:
     - `fmt.Println("No jobs found. Run 'ap start' to begin processing issues.")`

2. Add tests in `cmd/autopr/cli/list_test.go`
   - `TestRunListNoJobsShowsStartHint`
     - Setup temp config/db with zero jobs.
     - Set `cfgPath` to test config, `jsonOut = false`.
     - Call `runList` through stdout capture and assert exact string contains new hint.
   - `TestRunListNoJobsJSONStillWorks` (optional regression guard)
     - Same setup, set `jsonOut = true`.
     - Assert output is JSON array output (likely `[]`) and does not include human-readable “No jobs found…” message.

### 3) Risks / edge cases

1. Backward compatibility of automation/parsing
   - Some scripts may rely on exact legacy text `"No jobs found."`; update expectations if needed.
2. JSON mode behavior
   - Ensure the new message only affects non-JSON path; JSON path already returns data and should remain unchanged.
3. Command variants
   - Keep behavior consistent for all filters (`--project`, `--state`, `--cost`) since the empty-branch is global and should remain unchanged except text.
4. Test helper coupling
   - Reusing existing test helpers from the package is fine, but avoid duplicate brittle setup logic if one test config file format changes elsewhere.

### 4) Testing strategy

1. Unit tests (recommended)
   - Add the two tests above in `cmd/autopr/cli/list_test.go` and run:
     - `go test ./cmd/autopr/cli -run TestRunList`
2. Manual command checks
   - `ap list` when no jobs exist → confirm hint text appears.
   -

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `95793871`_
