### PR TITLE
[AutoPR] fix: ap version output missing build date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+DATE := $(shell date -u +%Y-%m-%d)
+VERSION := $(shell grep -m1 'const Version' internal/config/config.go | sed 's/.*"//;s/".*//')
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+LDFLAGS := -s -w \
+	-X autopr/cmd/autopr/cli.version=$(VERSION) \
+	-X autopr/cmd/autopr/cli.commit=$(COMMIT) \
+	-X autopr/cmd/autopr/cli.date=$(DATE)
+
+.PHONY: build
+build:
+	go build -ldflags "$(LDFLAGS)" -o ap ./cmd/autopr

--- a/cmd/autopr/cli/root.go
+++ b/cmd/autopr/cli/root.go
@@ -20,13 +20,14 @@ var (
 	jsonOut bool
 	version = config.Version
 	commit  = "unknown"
+	date    = "unknown"
 )
 
 var rootCmd = &cobra.Command{
 	Use:     "ap",
 	Short:   "AutoPR — autonomous issue-to-PR daemon",
 	Long:    "AutoPR watches your GitLab/GitHub/Sentry issues, then uses an LLM to plan, implement, test, and push fixes — ready for human approval.",
-	Version: fmt.Sprintf("%s (%s)", version, commit),
+	Version: fmt.Sprintf("%s (%s, %s)", version, commit, date),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		level := slog.LevelInfo
 		if verbose {

--- a/cmd/autopr/cli/root_test.go
+++ b/cmd/autopr/cli/root_test.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRootCmdVersionIncludesCommitAndDate(t *testing.T) {
+	want := fmt.Sprintf("%s (%s, %s)", version, commit, date)
+	if got := rootCmd.Version; got != want {
+		t.Fatalf("rootCmd.Version = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/ashwath-ramesh/autopr/issues/151

**Issue:** fix: ap version output missing build date

<details>
<summary>Plan</summary>

## Plan

1. **Files to modify/create**
- `cmd/autopr/cli/root.go:22` — add `date` linker variable.
- `cmd/autopr/cli/root.go:29` — change `Version` format to include both commit and date.
- `Makefile` — add/update `go build` `-ldflags` to inject `commit` and `date`.

2. **Implementation steps**
- Step 1: Update `cmd/autopr/cli/root.go` variables.
  - Add `date = "unknown"` next to `version` and `commit`.
  - Keep the type as `string` so `go build -ldflags -X` can inject values.
- Step 2: Update version string format in `cmd/autopr/cli/root.go`.
  - Change:
    - `Version: fmt.Sprintf("%s (%s)", version, commit)`
  - To:
    - `Version: fmt.Sprintf("%s (%s, %s)", version, commit, date)`
- Step 3: Update or add `Makefile` build rule.
  - Ensure the binary is built with linker flags for all three vars:
    - `autopr/cmd/autopr/cli.version` (existing)
    - `autopr/cmd/autopr/cli.commit` (existing)
    - `autopr/cmd/autopr/cli.date` (new)
  - Use explicit date format:
    - `DATE := $(shell date -u +%Y-%m-%d)`
  - Example output should become:
    - `-X autopr/cmd/autopr/cli.date=$(DATE)`

3. **Potential risks / edge cases**
- `Makefile` currently does not exist in this tree, so this change may require creating one or updating the actual build entrypoint used by CI.
- If CI/release builds do not pass `-ldflags`, output remains `(..., unknown)` for date (fallback behavior should remain acceptable).
- Go linker `-X` only replaces package-level `string` variables; keep variable names and package path exact.
- `date` format inconsistency across platforms if a non-GNU/BSD-compatible shell is used.
- Ensure no other code also sets `Version`, `commit`, or `date` via alternate build scripts.

4. **Testing strategy**
- Unit-level check (fast):
  - Add/extend a CLI test asserting default version string is:
    - `fmt.Sprintf("%s (unknown, unknown)", config.Version)`
    - against `rootCmd.Version` directly.
- Build-time check:
  - `go build -o /tmp/ap ./cmd/autopr`
  - `/tm

_(truncated)_
</details>

_Generated by [AutoPR](https://github.com/ashwath-ramesh/autopr) from job `637e60b8`_
