### PR TITLE
feat: add Linux release support with checksum verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,96 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    runs-on: macos-14
+  build-assets:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            goos: darwin
+            goarch: amd64
+          - runner: macos-14
+            goos: darwin
+            goarch: arm64
+          - runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - runner: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            cc: aarch64-linux-gnu-gcc
+            cxx: aarch64-linux-gnu-g++
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Install Linux arm64 cross compiler
+        if: runner.os == 'Linux' && matrix.goarch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Build binary
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
-          args: release --clean
+          args: build --clean --single-target --output dist/ap
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "1"
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+
+      - name: Package tarball
+        id: package
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARTIFACT="ap_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz"
+          tar -czf "${ARTIFACT}" -C dist ap
+          echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.package.outputs.artifact }}
+          path: ${{ steps.package.outputs.artifact }}
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish release assets
+    needs: build-assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: ap_*.tar.gz
+          path: dist/release
+          merge-multiple: true
+
+      - name: Prepare checksums
+        run: |
+          cd dist/release
+          sha256sum ap_*.tar.gz > checksums.txt
+
+      - name: Ensure release exists
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          fi
+
+      - name: Upload release files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" dist/release/ap_*.tar.gz dist/release/checksums.txt --clobber

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,12 +11,16 @@ builds:
       - -X autopr/cmd/autopr/cli.commit={{.ShortCommit}}
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64
 
+# NOTE: Current CI uses `goreleaser build` only. These blocks are kept in case we
+# switch back to `goreleaser release` later.
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: "ap_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ https://github.com/user-attachments/assets/80011a39-dd73-4052-8e2c-a67bc6244880
 
 ## 1. Install
 
-**macOS:**
+**macOS / Linux:**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ashwath-ramesh/autopr/master/scripts/install.sh | bash
 ```
+
+> Linux note: release binaries are CGO-enabled and linked against glibc. They are
+> intended for glibc distros (Ubuntu/Debian/RHEL, etc.), not Alpine/musl.
 
 Upgrade later from CLI:
 

--- a/cmd/autopr/cli/upgrade_test.go
+++ b/cmd/autopr/cli/upgrade_test.go
@@ -91,7 +91,7 @@ func TestRunUpgradeInstallsOnlyWhenNewer(t *testing.T) {
 func TestRunUpgradeSurfacesInstallErrors(t *testing.T) {
 	t.Parallel()
 
-	expectedErr := errors.New("unsupported OS \"linux\"")
+	expectedErr := errors.New("install failed")
 	err := runUpgradeWith(context.Background(), &bytes.Buffer{}, mockUpgradeService{
 		upgradeFn: func(context.Context, string) (update.UpgradeResult, error) {
 			return update.UpgradeResult{}, expectedErr
@@ -100,7 +100,7 @@ func TestRunUpgradeSurfacesInstallErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "unsupported OS") {
+	if !strings.Contains(err.Error(), "install failed") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,8 +9,8 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
 case "$OS" in
-  darwin) ;;
-  *) echo "Error: only macOS is supported right now." >&2; exit 1 ;;
+  darwin|linux) ;;
+  *) echo "Error: unsupported OS $OS (supported: darwin, linux)." >&2; exit 1 ;;
 esac
 
 case "$ARCH" in
@@ -34,10 +34,33 @@ echo "Installing ap v${TAG} (${OS}/${ARCH})..."
 # --- Download and extract ---
 TARBALL="ap_${TAG}_${OS}_${ARCH}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/v${TAG}/${TARBALL}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/v${TAG}/checksums.txt"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 curl -fsSL "$URL" -o "${TMP}/${TARBALL}"
+curl -fsSL "$CHECKSUMS_URL" -o "${TMP}/checksums.txt"
+
+EXPECTED_HASH=$(awk -v file="$TARBALL" '{name=$2; sub(/^\*/, "", name); if (name == file) print tolower($1)}' "${TMP}/checksums.txt")
+if [[ -z "$EXPECTED_HASH" ]]; then
+  echo "Error: checksum not found for ${TARBALL}." >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_HASH=$(sha256sum "${TMP}/${TARBALL}" | awk '{print tolower($1)}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_HASH=$(shasum -a 256 "${TMP}/${TARBALL}" | awk '{print tolower($1)}')
+else
+  echo "Error: no SHA-256 tool found (need sha256sum or shasum)." >&2
+  exit 1
+fi
+
+if [[ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]]; then
+  echo "Error: checksum verification failed for ${TARBALL}." >&2
+  exit 1
+fi
+
 tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
 
 # --- Install binary ---
@@ -52,7 +75,9 @@ mv "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"
 
 # macOS: remove quarantine attribute
-xattr -d com.apple.quarantine "${INSTALL_DIR}/${BINARY}" 2>/dev/null || true
+if [[ "$OS" == "darwin" ]]; then
+  xattr -d com.apple.quarantine "${INSTALL_DIR}/${BINARY}" 2>/dev/null || true
+fi
 
 echo ""
 echo "Installed: ${INSTALL_DIR}/${BINARY} (v${TAG})"


### PR DESCRIPTION
## Summary
- Adds Linux (amd64 + arm64) as a supported platform for install, self-upgrade, and CI release
- Rewrites release workflow to matrix build (darwin + linux) with separate publish job
- Adds SHA-256 checksum verification to both `install.sh` and the Go self-upgrade path
- Pins all GitHub Actions to commit SHAs for supply chain hardening
- Documents glibc requirement for Linux binaries

## Changes
- `.github/workflows/release.yml` — matrix build (4 targets) + publish job, pinned actions
- `.goreleaser.yaml` — adds `linux` to goos, updates `format` → `formats` for v2.6+
- `scripts/install.sh` — Linux OS support, checksum verification (sha256sum/shasum)
- `internal/update/update.go` — `selectAsset`, `selectChecksumsURL`, `fetchExpectedChecksum`, `checksumForAsset`; archive hash verified before extraction
- `internal/update/update_test.go` — Linux asset tests, checksum mismatch test, checksum parsing test
- `cmd/autopr/cli/upgrade_test.go` — updated error expectation
- `README.md` — install section updated for Linux, glibc note added

## Test plan
- [x] `go test ./internal/update/... ./cmd/autopr/cli/...` passes
- [x] `install.sh` runs successfully
- [x] `goreleaser check` passes
- [x] Checksum mismatch correctly rejected in tests